### PR TITLE
Hash data-redirect values

### DIFF
--- a/src/templates/_includes/editor-pane.html
+++ b/src/templates/_includes/editor-pane.html
@@ -42,9 +42,9 @@
 
             <div class="workflow-submission-footer btngroup">
                 {% if context.canSave %}
-                    <a class="formsubmit btn submit" data-param="workflow-action" data-value="save-submission" data-redirect="{{ context.saveShortcutRedirect }}">{{ "Save and submit for review" | t('workflow') }}</a>
+                    <a class="formsubmit btn submit" data-param="workflow-action" data-value="save-submission" data-redirect="{{ context.saveShortcutRedirect|hash }}">{{ "Save and submit for review" | t('workflow') }}</a>
                 {% else %}
-                    <a class="formsubmit btn submit" data-action="entry-revisions/save-draft" data-param="workflow-action" data-value="save-submission" data-redirect="{{ context.baseCpEditUrl ~ '/drafts/{draftId}' }}">{{ "Save draft and submit for review" | t('workflow') }}</a>
+                    <a class="formsubmit btn submit" data-action="entry-revisions/save-draft" data-param="workflow-action" data-value="save-submission" data-redirect="{{ (context.baseCpEditUrl ~ '/drafts/{draftId}')|hash }}">{{ "Save draft and submit for review" | t('workflow') }}</a>
                 {% endif %}
             </div>
         </div>
@@ -80,7 +80,7 @@
         <input type="hidden" name="submissionId" value="{{ submission.id }}">
 
         <div class="workflow-submission-footer">
-            <a class="formsubmit btn small" data-param="workflow-action" data-value="revoke-submission" data-redirect="{{ context.saveShortcutRedirect }}">{{ "Revoke submission" | t('workflow') }}</a>
+            <a class="formsubmit btn small" data-param="workflow-action" data-value="revoke-submission" data-redirect="{{ context.saveShortcutRedirect|hash }}">{{ "Revoke submission" | t('workflow') }}</a>
         </div>
     </div>
 {% endif %}
@@ -131,7 +131,7 @@
                             {% endif %}
                         </div>
                     </div>
-                </div>               
+                </div>
             {% elseif submission.status == 'revoked' %}
                 <div class="workflow-history">
                     <div class="workflow-history-heading">

--- a/src/templates/_includes/publisher-pane.html
+++ b/src/templates/_includes/publisher-pane.html
@@ -57,9 +57,9 @@
             <input type="hidden" name="submissionId" value="{{ submission.id }}">
 
             <div class="workflow-submission-footer btngroup">
-                <a class="formsubmit btn submit" data-param="workflow-action" data-value="approve-submission" data-redirect="{{ context.saveShortcutRedirect }}" {% if context.isDraft %}data-action="entry-revisions/publish-draft"{% endif %}>{{ "Approve and publish entry" | t('workflow') }}</a>
+                <a class="formsubmit btn submit" data-param="workflow-action" data-value="approve-submission" data-redirect="{{ context.saveShortcutRedirect|hash }}" {% if context.isDraft %}data-action="entry-revisions/publish-draft"{% endif %}>{{ "Approve and publish entry" | t('workflow') }}</a>
 
-                <a class="formsubmit btn" data-param="workflow-action" data-value="reject-submission" data-redirect="{{ context.saveShortcutRedirect }}">{{ "Reject" | t('workflow') }}</a>
+                <a class="formsubmit btn" data-param="workflow-action" data-value="reject-submission" data-redirect="{{ context.saveShortcutRedirect|hash }}">{{ "Reject" | t('workflow') }}</a>
             </div>
         </div>
     </div>
@@ -111,7 +111,7 @@
                             {% endif %}
                         </div>
                     </div>
-                </div>               
+                </div>
             {% elseif submission.status == 'revoked' %}
                 <div class="workflow-history">
                     <div class="workflow-history-heading">


### PR DESCRIPTION
In Craft 3, all `redirect` param values, including `data-redirect` attributes, must be hashed in order to work.

Craft 3.1.30 fixed a bug (craftcms/cms#4387) where `Craft::$app->security->validateData()` was returning an empty string instead of `false` when the data didn’t validate, so all of these unhashed `redirect` params were just looking to the controller as if they had been set to `''` rather than an invalid (unhashed) value. Now that that bug is fixed, Craft is correctly throwing 400 errors when you call `redirectToPostedUrl()` (as reported in #68).