### PR TITLE
Add multi-step review process

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 1.5.0 - Unreleased
+
+### Added
+- Added multi-step review process.
+
+### Fixed
+- Fix multi-site entries and their approval overriding the status of other-site entries.
+- Approving new entries respects section default status settings.
+- Fix date attributes for submissions not being localised.
+
 ## 1.4.8 - 2020-05-13
 
 ### Fixed

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "verbb/workflow",
     "description": "A Craft CMS plugin to create a workflow for publishing entries.",
     "type": "craft-plugin",
-    "version": "1.4.6",
+    "version": "1.5.0",
     "keywords": [
         "craft",
         "cms",

--- a/src/Workflow.php
+++ b/src/Workflow.php
@@ -100,6 +100,11 @@ class Workflow extends Plugin
         Event::on(SystemMessages::class, SystemMessages::EVENT_REGISTER_MESSAGES, function(RegisterEmailMessagesEvent $event) {
             $event->messages = array_merge($event->messages, [
                 [
+                    'key' => 'workflow_reviewer_notification',
+                    'heading' => Craft::t('workflow', 'workflow_reviewer_notification_heading'),
+                    'subject' => Craft::t('workflow', 'workflow_reviewer_notification_subject'),
+                    'body' => Craft::t('workflow', 'workflow_reviewer_notification_body'),
+                ], [
                     'key' => 'workflow_publisher_notification',
                     'heading' => Craft::t('workflow', 'workflow_publisher_notification_heading'),
                     'subject' => Craft::t('workflow', 'workflow_publisher_notification_subject'),

--- a/src/Workflow.php
+++ b/src/Workflow.php
@@ -28,6 +28,9 @@ use craft\web\twig\variables\CraftVariable;
 use yii\base\Event;
 use yii\web\User;
 
+/**
+ * @method Settings getSettings()
+ */
 class Workflow extends Plugin
 {
     // Public Properties

--- a/src/Workflow.php
+++ b/src/Workflow.php
@@ -105,20 +105,15 @@ class Workflow extends Plugin
                     'subject' => Craft::t('workflow', 'workflow_publisher_notification_subject'),
                     'body' => Craft::t('workflow', 'workflow_publisher_notification_body'),
                 ], [
-                    'key' => 'workflow_reviewer_notification',
-                    'heading' => Craft::t('workflow', 'workflow_reviewer_notification_heading'),
-                    'subject' => Craft::t('workflow', 'workflow_reviewer_notification_subject'),
-                    'body' => Craft::t('workflow', 'workflow_reviewer_notification_body'),
+                    'key' => 'workflow_editor_review_notification',
+                    'heading' => Craft::t('workflow', 'workflow_editor_review_notification_heading'),
+                    'subject' => Craft::t('workflow', 'workflow_editor_review_notification_subject'),
+                    'body' => Craft::t('workflow', 'workflow_editor_review_notification_body'),
                 ], [
                     'key' => 'workflow_editor_notification',
                     'heading' => Craft::t('workflow', 'workflow_editor_notification_heading'),
                     'subject' => Craft::t('workflow', 'workflow_editor_notification_subject'),
                     'body' => Craft::t('workflow', 'workflow_editor_notification_body'),
-                ], [
-                    'key' => 'workflow_editor_review_notification_heading',
-                    'heading' => Craft::t('workflow', 'workflow_editor_review_notification_heading_heading'),
-                    'subject' => Craft::t('workflow', 'workflow_editor_review_notification_heading_subject'),
-                    'body' => Craft::t('workflow', 'workflow_editor_review_notification_heading_body'),
                 ]
             ]);
         });

--- a/src/Workflow.php
+++ b/src/Workflow.php
@@ -100,15 +100,15 @@ class Workflow extends Plugin
         Event::on(SystemMessages::class, SystemMessages::EVENT_REGISTER_MESSAGES, function(RegisterEmailMessagesEvent $event) {
             $event->messages = array_merge($event->messages, [
                 [
-                    'key' => 'workflow_reviewer_notification',
-                    'heading' => Craft::t('workflow', 'workflow_reviewer_notification_heading'),
-                    'subject' => Craft::t('workflow', 'workflow_reviewer_notification_subject'),
-                    'body' => Craft::t('workflow', 'workflow_reviewer_notification_body'),
-                ], [
                     'key' => 'workflow_publisher_notification',
                     'heading' => Craft::t('workflow', 'workflow_publisher_notification_heading'),
                     'subject' => Craft::t('workflow', 'workflow_publisher_notification_subject'),
                     'body' => Craft::t('workflow', 'workflow_publisher_notification_body'),
+                ], [
+                    'key' => 'workflow_reviewer_notification',
+                    'heading' => Craft::t('workflow', 'workflow_reviewer_notification_heading'),
+                    'subject' => Craft::t('workflow', 'workflow_reviewer_notification_subject'),
+                    'body' => Craft::t('workflow', 'workflow_reviewer_notification_body'),
                 ], [
                     'key' => 'workflow_editor_notification',
                     'heading' => Craft::t('workflow', 'workflow_editor_notification_heading'),

--- a/src/Workflow.php
+++ b/src/Workflow.php
@@ -36,7 +36,7 @@ class Workflow extends Plugin
     // Public Properties
     // =========================================================================
 
-    public $schemaVersion = '2.1.3';
+    public $schemaVersion = '2.1.4';
     public $hasCpSettings = true;
     public $hasCpSection = true;
 

--- a/src/Workflow.php
+++ b/src/Workflow.php
@@ -114,6 +114,11 @@ class Workflow extends Plugin
                     'heading' => Craft::t('workflow', 'workflow_editor_notification_heading'),
                     'subject' => Craft::t('workflow', 'workflow_editor_notification_subject'),
                     'body' => Craft::t('workflow', 'workflow_editor_notification_body'),
+                ], [
+                    'key' => 'workflow_editor_review_notification_heading',
+                    'heading' => Craft::t('workflow', 'workflow_editor_review_notification_heading_heading'),
+                    'subject' => Craft::t('workflow', 'workflow_editor_review_notification_heading_subject'),
+                    'body' => Craft::t('workflow', 'workflow_editor_review_notification_heading_body'),
                 ]
             ]);
         });

--- a/src/base/PluginTrait.php
+++ b/src/base/PluginTrait.php
@@ -6,7 +6,6 @@ use verbb\workflow\services\Service;
 use verbb\workflow\services\Submissions;
 
 use Craft;
-use craft\log\FileTarget;
 
 use yii\log\Logger;
 

--- a/src/base/PluginTrait.php
+++ b/src/base/PluginTrait.php
@@ -17,17 +17,26 @@ trait PluginTrait
     // Static Properties
     // =========================================================================
 
+    /**
+     * @var Workflow $plugin
+     */
     public static $plugin;
 
 
     // Public Methods
     // =========================================================================
 
+    /**
+     * @return Service
+     */
     public function getService()
     {
         return $this->get('service');
     }
 
+    /**
+     * @return Submissions
+     */
     public function getSubmissions()
     {
         return $this->get('submissions');

--- a/src/elements/Submission.php
+++ b/src/elements/Submission.php
@@ -3,6 +3,8 @@ namespace verbb\workflow\elements;
 
 use verbb\workflow\elements\actions\SetStatus;
 use verbb\workflow\elements\db\SubmissionQuery;
+use verbb\workflow\models\Approval;
+use verbb\workflow\records\Approval as ApprovalRecord;
 use verbb\workflow\records\Submission as SubmissionRecord;
 
 use Craft;
@@ -96,7 +98,7 @@ class Submission extends Element
                 'label' => Craft::t('workflow', 'All submissions'),
             ]
         ];
-        
+
         return $sources;
     }
 
@@ -114,7 +116,7 @@ class Submission extends Element
 
         return $actions;
     }
-    
+
 
     // Public Methods
     // -------------------------------------------------------------------------
@@ -164,6 +166,23 @@ class Submission extends Element
         }
 
         return null;
+    }
+
+    public function getApprovals()
+    {
+        $approvals = [];
+
+        $records = ApprovalRecord::find()
+            ->where(['submissionId' => $this->id])
+            ->all();
+
+        foreach ($records as $record) {
+            $approval = new Approval();
+            $approval->setAttributes($record->getAttributes(), false);
+            $approvals[] = $approval;
+        }
+
+        return $approvals;
     }
 
     public function getEditorUrl()

--- a/src/elements/Submission.php
+++ b/src/elements/Submission.php
@@ -2,6 +2,7 @@
 namespace verbb\workflow\elements;
 
 use craft\elements\User;
+use craft\i18n\Locale;
 use verbb\workflow\elements\actions\SetStatus;
 use verbb\workflow\elements\db\SubmissionQuery;
 use verbb\workflow\models\Review;
@@ -374,13 +375,29 @@ class Submission extends Element
         return [
             'id' => ['label' => Craft::t('workflow', 'Entry')],
             'siteId' => ['label' => Craft::t('workflow', 'Site')],
-            'editor' => ['label' => Craft::t('workflow', 'Editor')],
             'dateCreated' => ['label' => Craft::t('workflow', 'Date Submitted')],
+            'editor' => ['label' => Craft::t('workflow', 'Editor')],
+            'lastReviewDate' => ['label' => Craft::t('workflow', 'Last Reviewed')],
+            'reviewer' => ['label' => Craft::t('workflow', 'Last Reviewed By')],
             'publisher' => ['label' => Craft::t('workflow', 'Publisher')],
             'editorNotes' => ['label' => Craft::t('workflow', 'Editor Notes')],
             'publisherNotes' => ['label' => Craft::t('workflow', 'Publisher Notes')],
             'dateApproved' => ['label' => Craft::t('workflow', 'Date Approved')],
             'dateRejected' => ['label' => Craft::t('workflow', 'Date Rejected')],
+        ];
+    }
+
+    protected static function defineDefaultTableAttributes(string $source): array
+    {
+        return [
+            'id',
+            'editor',
+            'dateCreated',
+            'reviewer',
+            'lastReviewDate',
+            'publisher',
+            'dateApproved',
+            'dateRejected',
         ];
     }
 
@@ -409,6 +426,21 @@ class Submission extends Element
             }
             case 'editor': {
                 return $this->getEditorUrl() ?: '-';
+            }
+            case 'reviewer': {
+                return $this->getLastReviewerUrl() ?: '-';
+            }
+            case 'lastReviewDate': {
+                $lastReview = $this->getLastReview();
+
+                if ($lastReview === null) {
+                    return '-';
+                }
+
+                $formatter = Craft::$app->getFormatter();
+                    return Html::tag('span', $formatter->asTimestamp($lastReview->dateCreated, Locale::LENGTH_SHORT), [
+                        'title' => $formatter->asDatetime($lastReview->dateCreated, Locale::LENGTH_SHORT)
+                    ]);
             }
             case 'dateApproved':
             case 'dateRejected': {

--- a/src/elements/Submission.php
+++ b/src/elements/Submission.php
@@ -306,13 +306,19 @@ class Submission extends Element
     }
 
     /**
-     * Returns whether a reviewer is allowed to review this submission.
+     * Returns whether a user is allowed to review this submission.
      *
-     * @param User $reviewer
+     * @param User $user
      * @return bool
      */
-    public function canReviewerReview(User $reviewer): bool
+    public function canUserReview(User $user): bool
     {
+        $publisherGroup = Craft::$app->userGroups->getGroupByUid(Workflow::$plugin->getSettings()->publisherUserGroup);
+
+        if ($user->isInGroup($publisherGroup)) {
+            return true;
+        }
+
         $lastReviewer = $this->getLastReviewer();
 
         if ($lastReviewer === null) {
@@ -325,7 +331,7 @@ class Submission extends Element
             if ($lastReviewer->isInGroup($userGroup)) {
                 $canReview = false;
             }
-            elseif ($reviewer->isInGroup($userGroup)) {
+            elseif ($user->isInGroup($userGroup)) {
                 $canReview = true;
             }
         }

--- a/src/elements/Submission.php
+++ b/src/elements/Submission.php
@@ -327,7 +327,7 @@ class Submission extends Element
 
         $canReview = false;
 
-        foreach (Workflow::$plugin->getSettings()->getReviewerUserGroups() as $key => $userGroup) {
+        foreach (Workflow::$plugin->getSubmissions()->getReviewerUserGroups($this) as $key => $userGroup) {
             if ($lastReviewer->isInGroup($userGroup)) {
                 $canReview = false;
             }

--- a/src/elements/Submission.php
+++ b/src/elements/Submission.php
@@ -3,8 +3,8 @@ namespace verbb\workflow\elements;
 
 use verbb\workflow\elements\actions\SetStatus;
 use verbb\workflow\elements\db\SubmissionQuery;
-use verbb\workflow\models\Approval;
-use verbb\workflow\records\Approval as ApprovalRecord;
+use verbb\workflow\models\Review;
+use verbb\workflow\records\Review as ApprovalRecord;
 use verbb\workflow\records\Submission as SubmissionRecord;
 
 use Craft;
@@ -177,7 +177,7 @@ class Submission extends Element
             ->all();
 
         foreach ($records as $record) {
-            $approval = new Approval();
+            $approval = new Review();
             $approval->setAttributes($record->getAttributes(), false);
             $approvals[] = $approval;
         }

--- a/src/elements/Submission.php
+++ b/src/elements/Submission.php
@@ -1,6 +1,7 @@
 <?php
 namespace verbb\workflow\elements;
 
+use craft\elements\User;
 use verbb\workflow\elements\actions\SetStatus;
 use verbb\workflow\elements\db\SubmissionQuery;
 use verbb\workflow\models\Review;
@@ -262,6 +263,23 @@ class Submission extends Element
         $reviews = $this->getReviews($approved);
 
         return end($reviews) ?: null;
+    }
+
+    /**
+     * Returns the last reviewer, optionally filtered by whether approved or not.
+     *
+     * @param bool|null
+     * @return User|null
+     */
+    public function getLastReviewer(bool $approved = null)
+    {
+        $lastReview = $this->getLastReview($approved);
+
+        if ($lastReview === null) {
+            return null;
+        }
+
+        return Craft::$app->getUsers()->getUserById($lastReview->userId);
     }
 
     public function afterSave(bool $isNew)

--- a/src/events/ReviewerUserGroupsEvent.php
+++ b/src/events/ReviewerUserGroupsEvent.php
@@ -2,12 +2,18 @@
 namespace verbb\workflow\events;
 
 use craft\models\UserGroup;
+use verbb\workflow\elements\Submission;
 use yii\base\Event;
 
 class ReviewerUserGroupsEvent extends Event
 {
     // Properties
     // =========================================================================
+
+    /**
+     * @var Submission|null
+     */
+    public $submission;
 
     /**
      * @var UserGroup[]

--- a/src/events/ReviewerUserGroupsEvent.php
+++ b/src/events/ReviewerUserGroupsEvent.php
@@ -1,0 +1,16 @@
+<?php
+namespace verbb\workflow\events;
+
+use craft\models\UserGroup;
+use yii\base\Event;
+
+class ReviewerUserGroupsEvent extends Event
+{
+    // Properties
+    // =========================================================================
+
+    /**
+     * @var UserGroup[]
+     */
+    public $userGroups;
+}

--- a/src/migrations/Install.php
+++ b/src/migrations/Install.php
@@ -1,7 +1,6 @@
 <?php
 namespace verbb\workflow\migrations;
 
-use Craft;
 use craft\db\Migration;
 use craft\helpers\MigrationHelper;
 
@@ -30,7 +29,6 @@ class Install extends Migration
             'ownerId' => $this->integer(),
             'ownerSiteId' => $this->integer(),
             'ownerDraftId' => $this->integer(),
-            'userGroupId' => $this->integer(),
             'editorId' => $this->integer(),
             'publisherId' => $this->integer(),
             'status' => $this->enum('status', ['approved', 'pending', 'rejected', 'revoked']),
@@ -45,10 +43,10 @@ class Install extends Migration
             'uid' => $this->uid(),
         ]);
 
-        $this->createTable('{{%workflow_approvals}}', [
+        $this->createTable('{{%workflow_reviews}}', [
             'id' => $this->primaryKey(),
             'submissionId' => $this->integer(),
-            'editorId' => $this->integer(),
+            'userId' => $this->integer(),
             'approved' => $this->boolean(),
             'notes' => $this->text(),
             'dateCreated' => $this->dateTime()->notNull(),
@@ -60,7 +58,7 @@ class Install extends Migration
     public function dropTables()
     {
         $this->dropTable('{{%workflow_submissions}}');
-        $this->dropTable('{{%workflow_approvals}}');
+        $this->dropTable('{{%workflow_reviews}}');
     }
 
     public function createIndexes()
@@ -82,8 +80,8 @@ class Install extends Migration
         $this->addForeignKey($this->db->getForeignKeyName('{{%workflow_submissions}}', 'ownerId'), '{{%workflow_submissions}}', 'ownerId', '{{%elements}}', 'id', 'SET NULL', null);
         $this->addForeignKey($this->db->getForeignKeyName('{{%workflow_submissions}}', 'publisherId'), '{{%workflow_submissions}}', 'publisherId', '{{%users}}', 'id', 'CASCADE', null);
 
-        $this->addForeignKey($this->db->getForeignKeyName('{{%workflow_approvals}}', 'submissionId'), '{{%workflow_approvals}}', 'submissionId', '{{%workflow_submissions}}', 'id', 'CASCADE', null);
-        $this->addForeignKey($this->db->getForeignKeyName('{{%workflow_approvals}}', 'editorId'), '{{%workflow_approvals}}', 'editorId', '{{%users}}', 'id', 'CASCADE', null);
+        $this->addForeignKey($this->db->getForeignKeyName('{{%workflow_reviews}}', 'submissionId'), '{{%workflow_reviews}}', 'submissionId', '{{%workflow_submissions}}', 'id', 'CASCADE', null);
+        $this->addForeignKey($this->db->getForeignKeyName('{{%workflow_reviews}}', 'userId'), '{{%workflow_reviews}}', 'userId', '{{%users}}', 'id', 'CASCADE', null);
     }
 
     public function dropForeignKeys()
@@ -95,7 +93,7 @@ class Install extends Migration
         MigrationHelper::dropForeignKeyIfExists('{{%workflow_submissions}}', ['ownerId'], $this);
         MigrationHelper::dropForeignKeyIfExists('{{%workflow_submissions}}', ['publisherId'], $this);
 
-        MigrationHelper::dropForeignKeyIfExists('{{%workflow_approvals}}', ['submissionId'], $this);
-        MigrationHelper::dropForeignKeyIfExists('{{%workflow_approvals}}', ['editorId'], $this);
+        MigrationHelper::dropForeignKeyIfExists('{{%workflow_reviews}}', ['submissionId'], $this);
+        MigrationHelper::dropForeignKeyIfExists('{{%workflow_reviews}}', ['userId'], $this);
     }
 }

--- a/src/migrations/Install.php
+++ b/src/migrations/Install.php
@@ -30,6 +30,7 @@ class Install extends Migration
             'ownerId' => $this->integer(),
             'ownerSiteId' => $this->integer(),
             'ownerDraftId' => $this->integer(),
+            'userGroupId' => $this->integer(),
             'editorId' => $this->integer(),
             'publisherId' => $this->integer(),
             'status' => $this->enum('status', ['approved', 'pending', 'rejected', 'revoked']),
@@ -43,13 +44,25 @@ class Install extends Migration
             'dateUpdated' => $this->dateTime()->notNull(),
             'uid' => $this->uid(),
         ]);
+
+        $this->createTable('{{%workflow_approvals}}', [
+            'id' => $this->primaryKey(),
+            'submissionId' => $this->integer(),
+            'editorId' => $this->integer(),
+            'approved' => $this->boolean(),
+            'notes' => $this->text(),
+            'dateCreated' => $this->dateTime()->notNull(),
+            'dateUpdated' => $this->dateTime()->notNull(),
+            'uid' => $this->uid(),
+        ]);
     }
-    
+
     public function dropTables()
     {
         $this->dropTable('{{%workflow_submissions}}');
+        $this->dropTable('{{%workflow_approvals}}');
     }
-    
+
     public function createIndexes()
     {
         $this->createIndex($this->db->getIndexName('{{%workflow_submissions}}', 'id', false), '{{%workflow_submissions}}', 'id', false);
@@ -68,8 +81,11 @@ class Install extends Migration
         $this->addForeignKey($this->db->getForeignKeyName('{{%workflow_submissions}}', 'editorId'), '{{%workflow_submissions}}', 'editorId', '{{%users}}', 'id', 'CASCADE', null);
         $this->addForeignKey($this->db->getForeignKeyName('{{%workflow_submissions}}', 'ownerId'), '{{%workflow_submissions}}', 'ownerId', '{{%elements}}', 'id', 'SET NULL', null);
         $this->addForeignKey($this->db->getForeignKeyName('{{%workflow_submissions}}', 'publisherId'), '{{%workflow_submissions}}', 'publisherId', '{{%users}}', 'id', 'CASCADE', null);
+
+        $this->addForeignKey($this->db->getForeignKeyName('{{%workflow_approvals}}', 'submissionId'), '{{%workflow_approvals}}', 'submissionId', '{{%workflow_submissions}}', 'id', 'CASCADE', null);
+        $this->addForeignKey($this->db->getForeignKeyName('{{%workflow_approvals}}', 'editorId'), '{{%workflow_approvals}}', 'editorId', '{{%users}}', 'id', 'CASCADE', null);
     }
-    
+
     public function dropForeignKeys()
     {
         MigrationHelper::dropForeignKeyIfExists('{{%workflow_submissions}}', ['id'], $this);
@@ -78,5 +94,8 @@ class Install extends Migration
         MigrationHelper::dropForeignKeyIfExists('{{%workflow_submissions}}', ['editorId'], $this);
         MigrationHelper::dropForeignKeyIfExists('{{%workflow_submissions}}', ['ownerId'], $this);
         MigrationHelper::dropForeignKeyIfExists('{{%workflow_submissions}}', ['publisherId'], $this);
+
+        MigrationHelper::dropForeignKeyIfExists('{{%workflow_approvals}}', ['submissionId'], $this);
+        MigrationHelper::dropForeignKeyIfExists('{{%workflow_approvals}}', ['editorId'], $this);
     }
 }

--- a/src/models/Approval.php
+++ b/src/models/Approval.php
@@ -1,0 +1,15 @@
+<?php
+namespace verbb\workflow\models;
+
+use craft\base\Model;
+
+class Approval extends Model
+{
+    // Public Properties
+    // =========================================================================
+
+    public $submissionId;
+    public $editorId;
+    public $approved = true;
+    public $notes = '';
+}

--- a/src/models/Review.php
+++ b/src/models/Review.php
@@ -12,4 +12,5 @@ class Review extends Model
     public $userId;
     public $approved = true;
     public $notes = '';
+    public $dateCreated = '';
 }

--- a/src/models/Review.php
+++ b/src/models/Review.php
@@ -3,13 +3,13 @@ namespace verbb\workflow\models;
 
 use craft\base\Model;
 
-class Approval extends Model
+class Review extends Model
 {
     // Public Properties
     // =========================================================================
 
     public $submissionId;
-    public $editorId;
+    public $userId;
     public $approved = true;
     public $notes = '';
 }

--- a/src/models/Review.php
+++ b/src/models/Review.php
@@ -13,4 +13,25 @@ class Review extends Model
     public $approved = true;
     public $notes = '';
     public $dateCreated = '';
+
+    // Static Methods
+    // =========================================================================
+
+    /**
+     * Populates a new model instance with a given set of attributes.
+     *
+     * @param mixed $values
+     * @return Review
+     */
+    public static function populateModel($values): Review
+    {
+        if ($values instanceof Model) {
+            $values = $values->getAttributes();
+        }
+
+        $review = new Review();
+        $review->setAttributes($values, false);
+
+        return $review;
+    }
 }

--- a/src/models/Settings.php
+++ b/src/models/Settings.php
@@ -4,9 +4,16 @@ namespace verbb\workflow\models;
 use Craft;
 use craft\base\Model;
 use craft\models\UserGroup;
+use verbb\workflow\events\ReviewerUserGroupsEvent;
+use yii\base\Event;
 
 class Settings extends Model
 {
+    // Constants
+    // =========================================================================
+
+    const EVENT_AFTER_GET_REVIEWER_USER_GROUPS = 'afterGetReviewerUserGroups';
+
     // Public Properties
     // =========================================================================
 
@@ -52,6 +59,13 @@ class Settings extends Model
             if ($userGroup !== null) {
                 $userGroups[] = $userGroup;
             }
+        }
+
+        // Fire an 'afterGetReviewerUserGroups' event
+        if ($this->hasEventHandlers(self::EVENT_AFTER_GET_REVIEWER_USER_GROUPS)) {
+            $this->trigger(self::EVENT_AFTER_GET_REVIEWER_USER_GROUPS,
+                new ReviewerUserGroupsEvent(['userGroups' => $userGroups])
+            );
         }
 
         return $userGroups;

--- a/src/models/Settings.php
+++ b/src/models/Settings.php
@@ -20,6 +20,7 @@ class Settings extends Model
     // Notifications
     public $editorNotifications = true;
     public $editorNotificationsOptions = [];
+    public $reviewerNotifications = true;
     public $publisherNotifications = true;
     public $selectedPublishers = '*';
 
@@ -30,7 +31,7 @@ class Settings extends Model
     // =========================================================================
 
     /**
-     * Returns an array of user groups that are editors in the multi-step approval process.
+     * Returns the reviewer user groups.
      *
      * @return UserGroup[]
      */
@@ -54,23 +55,5 @@ class Settings extends Model
         }
 
         return $userGroups;
-    }
-
-    /**
-     * Returns an array of approval steps with user group IDs as keys.
-     *
-     * @return array
-     */
-    public function getUserGroupApprovalSteps(): array
-    {
-        $approvalSteps = [];
-        $count = 0;
-
-        foreach ($this->getEditorUserGroups() as $userGroup) {
-            $count++;
-            $approvalSteps[$userGroup->id] = $count;
-        }
-
-        return $approvalSteps;
     }
 }

--- a/src/models/Settings.php
+++ b/src/models/Settings.php
@@ -1,7 +1,9 @@
 <?php
 namespace verbb\workflow\models;
 
+use Craft;
 use craft\base\Model;
+use craft\models\UserGroup;
 
 class Settings extends Model
 {
@@ -10,6 +12,7 @@ class Settings extends Model
 
     // General
     public $editorUserGroup;
+    public $editorUserGroups = [];
     public $publisherUserGroup;
     public $editorNotesRequired = false;
     public $publisherNotesRequired = false;
@@ -23,4 +26,51 @@ class Settings extends Model
     // Permissions
     public $enabledSections = '*';
 
+    // Public Methods
+    // =========================================================================
+
+    /**
+     * Returns an array of user groups that are editors in the multi-step approval process.
+     *
+     * @return UserGroup[]
+     */
+    public function getEditorUserGroups(): array
+    {
+        $userGroups = [];
+
+        foreach ($this->editorUserGroups as $editorUserGroup) {
+            // Get UI from first element in array
+            $uid = $editorUserGroup[0] ?? null;
+
+            if ($uid === null) {
+                continue;
+            }
+
+            $userGroup = Craft::$app->getUserGroups()->getGroupByUid($uid);
+
+            if ($userGroup !== null) {
+                $userGroups[] = $userGroup;
+            }
+        }
+
+        return $userGroups;
+    }
+
+    /**
+     * Returns an array of approval steps with user group IDs as keys.
+     *
+     * @return array
+     */
+    public function getUserGroupApprovalSteps(): array
+    {
+        $approvalSteps = [];
+        $count = 0;
+
+        foreach ($this->getEditorUserGroups() as $userGroup) {
+            $count++;
+            $approvalSteps[$userGroup->id] = $count;
+        }
+
+        return $approvalSteps;
+    }
 }

--- a/src/models/Settings.php
+++ b/src/models/Settings.php
@@ -12,7 +12,7 @@ class Settings extends Model
 
     // General
     public $editorUserGroup;
-    public $editorUserGroups = [];
+    public $reviewerUserGroups = [];
     public $publisherUserGroup;
     public $editorNotesRequired = false;
     public $publisherNotesRequired = false;
@@ -34,13 +34,13 @@ class Settings extends Model
      *
      * @return UserGroup[]
      */
-    public function getEditorUserGroups(): array
+    public function getReviewerUserGroups(): array
     {
         $userGroups = [];
 
-        foreach ($this->editorUserGroups as $editorUserGroup) {
-            // Get UI from first element in array
-            $uid = $editorUserGroup[0] ?? null;
+        foreach ($this->reviewerUserGroups as $reviewerUserGroup) {
+            // Get UID from first element in array
+            $uid = $reviewerUserGroup[0] ?? null;
 
             if ($uid === null) {
                 continue;

--- a/src/models/Settings.php
+++ b/src/models/Settings.php
@@ -1,19 +1,10 @@
 <?php
 namespace verbb\workflow\models;
 
-use Craft;
 use craft\base\Model;
-use craft\models\UserGroup;
-use verbb\workflow\events\ReviewerUserGroupsEvent;
-use yii\base\Event;
 
 class Settings extends Model
 {
-    // Constants
-    // =========================================================================
-
-    const EVENT_AFTER_GET_REVIEWER_USER_GROUPS = 'afterGetReviewerUserGroups';
-
     // Public Properties
     // =========================================================================
 
@@ -33,41 +24,4 @@ class Settings extends Model
 
     // Permissions
     public $enabledSections = '*';
-
-    // Public Methods
-    // =========================================================================
-
-    /**
-     * Returns the reviewer user groups.
-     *
-     * @return UserGroup[]
-     */
-    public function getReviewerUserGroups(): array
-    {
-        $userGroups = [];
-
-        foreach ($this->reviewerUserGroups as $reviewerUserGroup) {
-            // Get UID from first element in array
-            $uid = $reviewerUserGroup[0] ?? null;
-
-            if ($uid === null) {
-                continue;
-            }
-
-            $userGroup = Craft::$app->getUserGroups()->getGroupByUid($uid);
-
-            if ($userGroup !== null) {
-                $userGroups[] = $userGroup;
-            }
-        }
-
-        // Fire an 'afterGetReviewerUserGroups' event
-        if ($this->hasEventHandlers(self::EVENT_AFTER_GET_REVIEWER_USER_GROUPS)) {
-            $this->trigger(self::EVENT_AFTER_GET_REVIEWER_USER_GROUPS,
-                new ReviewerUserGroupsEvent(['userGroups' => $userGroups])
-            );
-        }
-
-        return $userGroups;
-    }
 }

--- a/src/records/Approval.php
+++ b/src/records/Approval.php
@@ -1,0 +1,29 @@
+<?php
+namespace verbb\workflow\records;
+
+use craft\db\ActiveRecord;
+use craft\records\User;
+
+use yii\db\ActiveQueryInterface;
+
+class Approval extends ActiveRecord
+{
+    // Public Methods
+    // =========================================================================
+
+    public static function tableName(): string
+    {
+        return '{{%workflow_submission_history}}';
+    }
+
+    public function getSubmission(): ActiveQueryInterface
+    {
+        return $this->hasOne(Submission::class, ['id' => 'submissionId']);
+    }
+
+    public function getUser(): ActiveQueryInterface
+    {
+        return $this->hasOne(User::class, ['id' => 'userId']);
+    }
+}
+

--- a/src/records/Review.php
+++ b/src/records/Review.php
@@ -4,8 +4,17 @@ namespace verbb\workflow\records;
 use craft\db\ActiveRecord;
 use craft\records\User;
 
+use DateTime;
 use yii\db\ActiveQueryInterface;
 
+/**
+ * @property int $id
+ * @property int $submissionId
+ * @property int $userId
+ * @property bool $approved
+ * @property string $notes
+ * @property DateTime $dateCreated
+ **/
 class Review extends ActiveRecord
 {
     // Public Methods
@@ -13,7 +22,7 @@ class Review extends ActiveRecord
 
     public static function tableName(): string
     {
-        return '{{%workflow_submission_history}}';
+        return '{{%workflow_reviews}}';
     }
 
     public function getSubmission(): ActiveQueryInterface

--- a/src/records/Review.php
+++ b/src/records/Review.php
@@ -6,7 +6,7 @@ use craft\records\User;
 
 use yii\db\ActiveQueryInterface;
 
-class Approval extends ActiveRecord
+class Review extends ActiveRecord
 {
     // Public Methods
     // =========================================================================

--- a/src/resources/dist/js/EditorUserGroupSelectInput.js
+++ b/src/resources/dist/js/EditorUserGroupSelectInput.js
@@ -1,0 +1,43 @@
+/** global: Craft */
+/** global: Garnish */
+/**
+ * Editor User Group Select Input
+ */
+Craft.EditorUserGroupSelectInput = Garnish.Base.extend(
+    {
+        id: null,
+        editorUserGroups: [],
+
+        sort: null,
+        $container: null,
+
+        init: function(id, editorUserGroups) {
+            this.id = id;
+            this.editorUserGroups = editorUserGroups;
+            this.$container = $('#' + this.id);
+
+            this.initSort();
+        },
+
+        initSort: function() {
+            this.sort = new Garnish.DragSort({
+                container: this.$container,
+                // filter: $.proxy(function() {
+                //     // Only return all the selected items if the target item is selected
+                //     if (this.elementSort.$targetItem.hasClass('sel')) {
+                //         return this.elementSelect.getSelectedItems();
+                //     } else {
+                //         return this.elementSort.$targetItem;
+                //     }
+                // }, this),
+                ignoreHandleSelector: '.delete',
+                // axis: this.getElementSortAxis(),
+                collapseDraggees: true,
+                magnetStrength: 4,
+                helperLagBase: 1.5,
+                // onSortChange: (this.settings.selectable ? $.proxy(function() {
+                //         this.elementSelect.resetItemOrder();
+                //     }, this) : null)
+            });
+        },
+    });

--- a/src/services/Service.php
+++ b/src/services/Service.php
@@ -1,7 +1,6 @@
 <?php
 namespace verbb\workflow\services;
 
-use verbb\workflow\records\Approval;
 use verbb\workflow\Workflow;
 use verbb\workflow\elements\Submission;
 
@@ -9,18 +8,14 @@ use Craft;
 use craft\base\Component;
 use craft\base\Element;
 use craft\db\Table;
-use craft\elements\Entry;
 use craft\events\DraftEvent;
 use craft\events\ModelEvent;
 use craft\helpers\DateTimeHelper;
 use craft\helpers\Db;
 use craft\helpers\ElementHelper;
-use craft\helpers\StringHelper;
 use craft\helpers\UrlHelper;
 
 use DateTime;
-
-use yii\base\ModelEvent as YiiModelEvent;
 
 class Service extends Component
 {

--- a/src/services/Service.php
+++ b/src/services/Service.php
@@ -188,8 +188,8 @@ class Service extends Component
         }
 
         // Show the sidebar submission button for reviewers
-        foreach ($settings->getReviewerUserGroups() as $reviewerUserGroup) {
-            if ($currentUser->isInGroup($reviewerUserGroup)) {
+        foreach ($settings->getReviewerUserGroups() as $userGroup) {
+            if ($currentUser->isInGroup($userGroup)) {
                 return $this->_renderEntrySidebarPanel($context, 'reviewer-pane');
             }
         }

--- a/src/services/Service.php
+++ b/src/services/Service.php
@@ -42,12 +42,18 @@ class Service extends Component
                 ->limit(1)
                 ->status('pending')
                 ->orderBy('dateCreated desc')
-                ->exists();
+                ->one();
 
-            if ($submission) {
-                $event->isValid = false;
+            if ($submission !== null) {
+                $currentUser = Craft::$app->getUser()->getIdentity();
 
-                $event->sender->addError('error', Craft::t('workflow', 'Unable to edit entry once it has been submitted for review.'));
+                // Ensure current user is allowed to review the submission
+                /** @var Submission $submission */
+                if (!$submission->canUserReview($currentUser)) {
+                    $event->isValid = false;
+
+                    $event->sender->addError('error', Craft::t('workflow', 'Unable to edit entry once it has been submitted for review.'));
+                }
             }
         }
 

--- a/src/services/Service.php
+++ b/src/services/Service.php
@@ -63,7 +63,20 @@ class Service extends Component
                 return;
             }
 
-            // If we are approving a submission, make sure to make it live
+            // For multi-sites, we only want to act on the current site's entry. Returning early will respect the
+            // section defaults for enabling the entry per-site.
+            if (Craft::$app->getIsMultiSite()) {
+                $currentSiteId = Craft::$app->getSites()->getCurrentSite()->id;
+
+                if ($siteHandle = $request->getParam('site')) {
+                    $currentSiteId = Craft::$app->getSites()->getSiteByHandle($siteHandle)->id;
+                }
+
+                if ($event->sender->siteId != $currentSiteId) {
+                    return;
+                }
+            }
+
             $event->sender->enabled = true;
             $event->sender->enabledForSite = true;
             $event->sender->setScenario(Element::SCENARIO_LIVE);

--- a/src/services/Submissions.php
+++ b/src/services/Submissions.php
@@ -166,11 +166,9 @@ class Submissions extends Component
             return null;
         }
 
-        $review = Review::populateModel($reviewRecord);
-
         // Trigger notification to editor
         if ($settings->reviewerNotifications) {
-            $this->sendReviewerNotificationEmail($submission, $review);
+            $this->sendReviewerNotificationEmail($submission);
         }
 
         $session->setNotice(Craft::t('workflow', 'Submission approved.'));

--- a/src/services/Submissions.php
+++ b/src/services/Submissions.php
@@ -375,7 +375,13 @@ class Submissions extends Component
         }
     }
 
-    public function sendEditorNotificationEmail($submission, $review = null)
+    /**
+     * Sends a notification email to the editor.
+     *
+     * @param Submission $submission
+     * @param Review|null $review
+     */
+    public function sendEditorNotificationEmail($submission, Review $review = null)
     {
         $settings = Workflow::$plugin->getSettings();
 
@@ -413,6 +419,19 @@ class Submissions extends Component
 
                         if (in_array('cc', $settings->editorNotificationsOptions)) {
                             $mail->setCc($submission->publisher->email);
+                        }
+                    }
+                }
+                else {
+                    $reviewer = $submission->getLastReviewer();
+
+                    if ($reviewer !== null) {
+                        if (in_array('replyToReviewer', $settings->editorNotificationsOptions)) {
+                            $mail->setReplyTo($reviewer->email);
+                        }
+
+                        if (in_array('ccReviewer', $settings->editorNotificationsOptions)) {
+                            $mail->setCc($reviewer->email);
                         }
                     }
                 }

--- a/src/services/Submissions.php
+++ b/src/services/Submissions.php
@@ -43,18 +43,17 @@ class Submissions extends Component
     {
         $reviewerUserGroups = Workflow::$plugin->getSettings()->getReviewerUserGroups();
 
-        $lastApprovedReview = $submission->getLastReview(true);
+        $lastReviewer = $submission->getLastReviewer(true);
 
-        if ($lastApprovedReview === null) {
+        if ($lastReviewer === null) {
             return $reviewerUserGroups[0] ?? null;
         }
 
-        $reviewer = Craft::$app->getUsers()->getUserById($lastApprovedReview->userId);
         $nextUserGroup = null;
 
-        foreach ($reviewerUserGroups as $key => $reviewerUserGroup) {
-            if ($reviewer->isInGroup($reviewerUserGroup)) {
-                $nextUserGroup = $reviewerUserGroups[$key + 1] ?? $nextUserGroup;
+        foreach ($reviewerUserGroups as $key => $userGroup) {
+            if ($lastReviewer->isInGroup($userGroup)) {
+                $nextUserGroup = $userGroups[$key + 1] ?? $nextUserGroup;
             }
         }
 
@@ -186,6 +185,8 @@ class Submissions extends Component
         $session = Craft::$app->getSession();
 
         $submission = $this->_setSubmissionFromPost();
+        $submission->status = Submission::STATUS_REJECTED;
+        $submission->dateRejected = new \DateTime;
 
         if (!Craft::$app->getElements()->saveElement($submission)) {
             $session->setError(Craft::t('workflow', 'Could not approve submission.'));

--- a/src/services/Submissions.php
+++ b/src/services/Submissions.php
@@ -314,7 +314,7 @@ class Submissions extends Component
         foreach ($reviewers as $key => $user) {
             try {
                 $mail = Craft::$app->getMailer()
-                    ->composeFromKey('workflow_reviewer_notification', ['submission' => $submission])
+                    ->composeFromKey('workflow_publisher_notification', ['submission' => $submission])
                     ->setTo($user);
 
                 // Fire a 'beforeSendPublisherEmail' event

--- a/src/services/Submissions.php
+++ b/src/services/Submissions.php
@@ -169,8 +169,8 @@ class Submissions extends Component
         $review = Review::populateModel($reviewRecord);
 
         // Trigger notification to editor
-        if ($settings->editorNotifications) {
-            $this->sendEditorNotificationEmail($submission, $review);
+        if ($settings->reviewerNotifications) {
+            $this->sendReviewerNotificationEmail($submission, $review);
         }
 
         $session->setNotice(Craft::t('workflow', 'Submission approved.'));
@@ -386,10 +386,7 @@ class Submissions extends Component
     {
         $settings = Workflow::$plugin->getSettings();
 
-        $groupId = Db::idByUid(Table::USERGROUPS, $settings->editorUserGroup);
-
         $editor = User::find()
-            ->groupId($groupId)
             ->id($submission->editorId)
             ->one();
 

--- a/src/services/Submissions.php
+++ b/src/services/Submissions.php
@@ -2,7 +2,6 @@
 namespace verbb\workflow\services;
 
 use craft\models\UserGroup;
-use verbb\workflow\models\Review;
 use verbb\workflow\records\Review as ReviewRecord;
 use verbb\workflow\Workflow;
 use verbb\workflow\elements\Submission;
@@ -149,7 +148,7 @@ class Submissions extends Component
             return null;
         }
 
-        $review = new Review([
+        $review = new ReviewRecord([
             'submissionId' => $submission->id,
             'userId' => $currentUser->id,
             'approved' => true,
@@ -194,7 +193,7 @@ class Submissions extends Component
             return null;
         }
 
-        $review = new Review([
+        $review = new ReviewRecord([
             'submissionId' => $submission->id,
             'userId' => $currentUser->id,
             'approved' => false,
@@ -309,7 +308,10 @@ class Submissions extends Component
         foreach ($reviewers as $key => $user) {
             try {
                 $mail = Craft::$app->getMailer()
-                    ->composeFromKey('workflow_reviewer_notification', ['submission' => $submission])
+                    ->composeFromKey('workflow_reviewer_notification', [
+                        'submission' => $submission,
+                        'review' => $submission->getLastReview(),
+                    ])
                     ->setTo($user);
 
                 // Fire a 'beforeSendPublisherEmail' event

--- a/src/templates/_includes/editor-pane.html
+++ b/src/templates/_includes/editor-pane.html
@@ -23,7 +23,7 @@
             </div>
 
             <div class="instructions">
-                <p>{{ "Submitting this entry for review will lock further edits and notify your publisher that this entry is ready for approval." | t('workflow') }}</p>
+                <p>{{ "Submitting this entry for review will lock further edits and notify the next editors in the approval process that this entry is ready for approval." | t('workflow') }}</p>
             </div>
 
             <div class="workflow-submission-body">
@@ -49,9 +49,8 @@
             </div>
         </div>
     </div>
-{% endif %}
 
-{% if pendingSubmissions | length %}
+{% else %}
     {% set submission = pendingSubmissions[0] %}
 
     <div class="pane workflow-pane">
@@ -64,7 +63,7 @@
 
             <div id="workflow-submission-info" class="hidden">
                 <div class="instructions">
-                    <p style="color: #da5a47;">{{ "This entry has been submitted for review on {date} and is awaiting approval. Changes cannot be made until approved." | t('workflow', { date: submission.dateCreated | date('jS M Y g:ia') }) }}</p>
+                    <p style="color: #da5a47;">{{ "This entry was submitted for review on {date} and is awaiting approval. Changes cannot be made until approved." | t('workflow', { date: submission.dateCreated | date('jS M Y g:ia') }) }}</p>
 
                     {% if submission.editorNotes %}
                         <p class="code">{{ 'Editor Notes' | t('workflow') }}: "{{ submission.editorNotes }}"</p>

--- a/src/templates/_includes/editor-pane.html
+++ b/src/templates/_includes/editor-pane.html
@@ -69,6 +69,10 @@
                         <p class="code">{{ 'Editor Notes' | t('workflow') }}: "{{ submission.editorNotes }}"</p>
                     {% endif %}
 
+                    {% for review in submission.getReviews() %}
+                        <p class="code">{{ 'Reviewer Notes' | t('workflow') }}: "{{ review.notes }}"</p>
+                    {% endfor %}
+
                     {% if submission.publisherNotes %}
                         <p class="code">{{ 'Publisher Notes' | t('workflow') }}: "{{ submission.publisherNotes }}"</p>
                     {% endif %}
@@ -103,6 +107,10 @@
                                 <p class="code">{{ 'Editor Notes' | t('workflow') }}: "{{ submission.editorNotes }}"</p>
                             {% endif %}
 
+                            {% for review in submission.getReviews() %}
+                                <p class="code">{{ 'Reviewer Notes' | t('workflow') }}: "{{ review.notes }}"</p>
+                            {% endfor %}
+
                             {% if submission.publisherNotes %}
                                 <p class="code">{{ 'Publisher Notes' | t('workflow') }}: "{{ submission.publisherNotes }}"</p>
                             {% endif %}
@@ -125,6 +133,10 @@
                                 <p class="code">{{ 'Editor Notes' | t('workflow') }}: "{{ submission.editorNotes }}"</p>
                             {% endif %}
 
+                            {% for review in submission.getReviews() %}
+                                <p class="code">{{ 'Reviewer Notes' | t('workflow') }}: "{{ review.notes }}"</p>
+                            {% endfor %}
+
                             {% if submission.publisherNotes %}
                                 <p class="code">{{ 'Publisher Notes' | t('workflow') }}: "{{ submission.publisherNotes }}"</p>
                             {% endif %}
@@ -146,6 +158,10 @@
                             {% if submission.editorNotes %}
                                 <p class="code">{{ 'Editor Notes' | t('workflow') }}: "{{ submission.editorNotes }}"</p>
                             {% endif %}
+
+                            {% for review in submission.getReviews() %}
+                                <p class="code">{{ 'Reviewer Notes' | t('workflow') }}: "{{ review.notes }}"</p>
+                            {% endfor %}
 
                             {% if submission.publisherNotes %}
                                 <p class="code">{{ 'Publisher Notes' | t('workflow') }}: "{{ submission.publisherNotes }}"</p>

--- a/src/templates/_includes/editor-pane.html
+++ b/src/templates/_includes/editor-pane.html
@@ -127,7 +127,8 @@
 
                     <div id="history-info-{{ loop.index }}" class="workflow-history-info hidden">
                         <div class="instructions">
-                            <p>{{ submission.publisherUrl | raw }} {{ "rejected this entry on {date}." | t('workflow', { date: submission.dateRejected | date('jS M Y g:ia') }) }}</p>
+                            {% set url = submission.publisherUrl ?: submission.lastReviewerUrl %}
+                            <p>{{ url | raw }} {{ "rejected this entry on {date}." | t('workflow', { date: submission.dateRejected | date('jS M Y g:ia') }) }}</p>
 
                             {% if submission.editorNotes %}
                                 <p class="code">{{ 'Editor Notes' | t('workflow') }}: "{{ submission.editorNotes }}"</p>

--- a/src/templates/_includes/publisher-pane.html
+++ b/src/templates/_includes/publisher-pane.html
@@ -128,7 +128,8 @@
 
                     <div id="history-info-{{ loop.index }}" class="workflow-history-info hidden">
                         <div class="instructions">
-                            <p>{{ submission.publisherUrl | raw }} {{ "rejected this entry on {date}." | t('workflow', { date: submission.dateRejected | date('jS M Y g:ia') }) }}</p>
+                            {% set url = submission.publisherUrl ?: submission.lastReviewerUrl %}
+                            <p>{{ url | raw }} {{ "rejected this entry on {date}." | t('workflow', { date: submission.dateRejected | date('jS M Y g:ia') }) }}</p>
 
                             {% if submission.editorNotes %}
                                 <p class="code">{{ 'Editor Notes' | t('workflow') }}: "{{ submission.editorNotes }}"</p>

--- a/src/templates/_includes/publisher-pane.html
+++ b/src/templates/_includes/publisher-pane.html
@@ -34,6 +34,10 @@
                         <p class="code">{{ 'Editor Notes' | t('workflow') }}: "{{ submission.editorNotes }}"</p>
                     {% endif %}
 
+                    {% for review in submission.getReviews() %}
+                        <p class="code">{{ 'Reviewer Notes' | t('workflow') }}: "{{ review.notes }}"</p>
+                    {% endfor %}
+
                     {% if submission.publisherNotes %}
                         <p class="code">{{ 'Publisher Notes' | t('workflow') }}: "{{ submission.publisherNotes }}"</p>
                     {% endif %}
@@ -104,6 +108,10 @@
                                 <p class="code">{{ 'Editor Notes' | t('workflow') }}: "{{ submission.editorNotes }}"</p>
                             {% endif %}
 
+                            {% for review in submission.getReviews() %}
+                                <p class="code">{{ 'Reviewer Notes' | t('workflow') }}: "{{ review.notes }}"</p>
+                            {% endfor %}
+
                             {% if submission.publisherNotes %}
                                 <p class="code">{{ 'Publisher Notes' | t('workflow') }}: "{{ submission.publisherNotes }}"</p>
                             {% endif %}
@@ -126,6 +134,10 @@
                                 <p class="code">{{ 'Editor Notes' | t('workflow') }}: "{{ submission.editorNotes }}"</p>
                             {% endif %}
 
+                            {% for review in submission.getReviews() %}
+                                <p class="code">{{ 'Reviewer Notes' | t('workflow') }}: "{{ review.notes }}"</p>
+                            {% endfor %}
+
                             {% if submission.publisherNotes %}
                                 <p class="code">{{ 'Publisher Notes' | t('workflow') }}: "{{ submission.publisherNotes }}"</p>
                             {% endif %}
@@ -147,6 +159,10 @@
                             {% if submission.editorNotes %}
                                 <p class="code">{{ 'Editor Notes' | t('workflow') }}: "{{ submission.editorNotes }}"</p>
                             {% endif %}
+
+                            {% for review in submission.getReviews() %}
+                                <p class="code">{{ 'Reviewer Notes' | t('workflow') }}: "{{ review.notes }}"</p>
+                            {% endfor %}
 
                             {% if submission.publisherNotes %}
                                 <p class="code">{{ 'Publisher Notes' | t('workflow') }}: "{{ submission.publisherNotes }}"</p>

--- a/src/templates/_includes/reviewer-pane.html
+++ b/src/templates/_includes/reviewer-pane.html
@@ -36,7 +36,7 @@
 
                     {% set reviews = submission.getReviews() %}
                     {% for review in reviews %}
-                        <p class="code">{{ 'Reviewer Notes' | t('workflow') }}: "{{ reviewer.notes }}"</p>
+                        <p class="code">{{ 'Reviewer Notes' | t('workflow') }}: "{{ review.notes }}"</p>
                     {% endfor %}
                 </div>
             </div>
@@ -54,7 +54,7 @@
 
             <input type="hidden" name="submissionId" value="{{ submission.id }}">
 
-            <div class="workflow-submission-footer">
+            <div class="workflow-submission-footer btngroup">
                 <div id="save-btn-container" class="submit">
                     <a class="btn formsubmit submit" data-action="workflow/submissions/save-draft" data-param="workflow-action" data-value="approve-review" data-redirect="{{ craft.app.request.url | hash }}">{{ "Approve" | t('workflow') }}</a>
                 </div>
@@ -86,7 +86,7 @@
 
                             {% set reviews = submission.getReviews() %}
                             {% for review in reviews %}
-                                <p class="code">{{ 'Reviewer Notes' | t('workflow') }}: "{{ reviewer.notes }}"</p>
+                                <p class="code">{{ 'Reviewer Notes' | t('workflow') }}: "{{ review.notes }}"</p>
                             {% endfor %}
 
                             {% if submission.publisherNotes %}
@@ -113,7 +113,7 @@
 
                             {% set reviews = submission.getReviews() %}
                             {% for review in reviews %}
-                                <p class="code">{{ 'Reviewer Notes' | t('workflow') }}: "{{ reviewer.notes }}"</p>
+                                <p class="code">{{ 'Reviewer Notes' | t('workflow') }}: "{{ review.notes }}"</p>
                             {% endfor %}
 
                             {% if submission.publisherNotes %}
@@ -140,7 +140,7 @@
 
                             {% set reviews = submission.getReviews() %}
                             {% for review in reviews %}
-                                <p class="code">{{ 'Reviewer Notes' | t('workflow') }}: "{{ reviewer.notes }}"</p>
+                                <p class="code">{{ 'Reviewer Notes' | t('workflow') }}: "{{ review.notes }}"</p>
                             {% endfor %}
 
                             {% if submission.publisherNotes %}

--- a/src/templates/_includes/reviewer-pane.html
+++ b/src/templates/_includes/reviewer-pane.html
@@ -18,50 +18,81 @@
 {% if pendingSubmissions | length %}
     {% set submission = pendingSubmissions[0] %}
 
-    <div class="pane workflow-pane">
-        <div class="workflow-submission">
-            <div class="workflow-submission-heading">
-                <span class="status pending"></span>
-                <label>{{ "Awaiting review" | t('workflow') }}</label>
-                <a class="fieldtoggle" data-target="workflow-submission-info"></a>
-            </div>
-
-            <div id="workflow-submission-info" class="hidden">
-                <div class="instructions">
-                    <p>{{ submission.editorUrl | raw }} {{ "submitted this entry for review on {date}. Please review this entry before approving." | t('workflow', { date: submission.dateCreated | date('jS M Y g:ia') }) }}</p>
-
-                    {% if submission.editorNotes %}
-                        <p class="code">{{ 'Editor Notes' | t('workflow') }}: "{{ submission.editorNotes }}"</p>
-                    {% endif %}
-
-                    {% for review in submission.getReviews() %}
-                        <p class="code">{{ 'Reviewer Notes' | t('workflow') }}: "{{ review.notes }}"</p>
-                    {% endfor %}
-                </div>
-            </div>
-
-            <div class="workflow-submission-body">
-                {{ forms.textareaField({
-                    placeholder: 'Notes about your response.' | t('workflow'),
-                    id: 'notes',
-                    name: 'notes',
-                    class: 'field-notes',
-                    rows: 2,
-                    errors: notesErrors is defined ? notesErrors,
-                }) }}
-            </div>
-
-            <input type="hidden" name="submissionId" value="{{ submission.id }}">
-
-            <div class="workflow-submission-footer btngroup">
-                <div id="save-btn-container" class="submit">
-                    <a class="btn formsubmit submit" data-action="workflow/submissions/save-draft" data-param="workflow-action" data-value="approve-review" data-redirect="{{ craft.app.request.url | hash }}">{{ "Approve" | t('workflow') }}</a>
+    {% if submission.canReviewerReview(currentUser) %}
+        <div class="pane workflow-pane">
+            <div class="workflow-submission">
+                <div class="workflow-submission-heading">
+                    <span class="status pending"></span>
+                    <label>{{ "Awaiting review" | t('workflow') }}</label>
+                    <a class="fieldtoggle" data-target="workflow-submission-info"></a>
                 </div>
 
-                <a class="formsubmit btn" data-action="workflow/submissions/save-draft" data-param="workflow-action" data-value="reject-review" data-redirect="{{ craft.app.request.url | hash }}">{{ "Reject" | t('workflow') }}</a>
+                <div id="workflow-submission-info" class="hidden">
+                    <div class="instructions">
+                        <p>{{ submission.editorUrl | raw }} {{ "submitted this entry for review on {date}. Please review this entry before approving." | t('workflow', { date: submission.dateCreated | date('jS M Y g:ia') }) }}</p>
+
+                        {% if submission.editorNotes %}
+                            <p class="code">{{ 'Editor Notes' | t('workflow') }}: "{{ submission.editorNotes }}"</p>
+                        {% endif %}
+
+                        {% for review in submission.getReviews() %}
+                            <p class="code">{{ 'Reviewer Notes' | t('workflow') }}: "{{ review.notes }}"</p>
+                        {% endfor %}
+                    </div>
+                </div>
+
+                <div class="workflow-submission-body">
+                    {{ forms.textareaField({
+                        placeholder: 'Notes about your response.' | t('workflow'),
+                        id: 'notes',
+                        name: 'notes',
+                        class: 'field-notes',
+                        rows: 2,
+                        errors: notesErrors is defined ? notesErrors,
+                    }) }}
+                </div>
+
+                <input type="hidden" name="submissionId" value="{{ submission.id }}">
+
+                <div class="workflow-submission-footer btngroup">
+                    <div id="save-btn-container" class="submit">
+                        <a class="btn formsubmit submit" data-action="workflow/submissions/save-draft" data-param="workflow-action" data-value="approve-review" data-redirect="{{ craft.app.request.url | hash }}">{{ "Approve" | t('workflow') }}</a>
+                    </div>
+
+                    <a class="formsubmit btn" data-action="workflow/submissions/save-draft" data-param="workflow-action" data-value="reject-review" data-redirect="{{ craft.app.request.url | hash }}">{{ "Reject" | t('workflow') }}</a>
+                </div>
             </div>
         </div>
-    </div>
+
+    {% else %}
+        <div class="pane workflow-pane">
+            <div class="workflow-submission">
+                <div class="workflow-submission-heading">
+                    <span class="status pending"></span>
+                    <label>{{ "Awaiting approval" | t('workflow') }}</label>
+                    <a class="fieldtoggle" data-target="workflow-submission-info"></a>
+                </div>
+
+                <div id="workflow-submission-info" class="hidden">
+                    <div class="instructions">
+                        <p style="color: #da5a47;">{{ "This entry was submitted for review on {date} and is awaiting approval. Changes cannot be made until approved." | t('workflow', { date: submission.dateCreated | date('jS M Y g:ia') }) }}</p>
+
+                        {% if submission.editorNotes %}
+                            <p class="code">{{ 'Editor Notes' | t('workflow') }}: "{{ submission.editorNotes }}"</p>
+                        {% endif %}
+
+                        {% for review in submission.getReviews() %}
+                            <p class="code">{{ 'Reviewer Notes' | t('workflow') }}: "{{ review.notes }}"</p>
+                        {% endfor %}
+
+                        {% if submission.publisherNotes %}
+                            <p class="code">{{ 'Publisher Notes' | t('workflow') }}: "{{ submission.publisherNotes }}"</p>
+                        {% endif %}
+                    </div>
+                </div>
+            </div>
+        </div>
+    {% endif %}
 {% endif %}
 
 {% if nonPendingSubmissions | length %}
@@ -103,7 +134,8 @@
 
                     <div id="history-info-{{ loop.index }}" class="workflow-history-info hidden">
                         <div class="instructions">
-                            <p>{{ submission.publisherUrl | raw }} {{ "rejected this entry on {date}." | t('workflow', { date: submission.dateRejected | date('jS M Y g:ia') }) }}</p>
+                            {% set url = submission.publisherUrl ?: submission.lastReviewerUrl %}
+                            <p>{{ url | raw }} {{ "rejected this entry on {date}." | t('workflow', { date: submission.dateRejected | date('jS M Y g:ia') }) }}</p>
 
                             {% if submission.editorNotes %}
                                 <p class="code">{{ 'Editor Notes' | t('workflow') }}: "{{ submission.editorNotes }}"</p>

--- a/src/templates/_includes/reviewer-pane.html
+++ b/src/templates/_includes/reviewer-pane.html
@@ -34,8 +34,7 @@
                         <p class="code">{{ 'Editor Notes' | t('workflow') }}: "{{ submission.editorNotes }}"</p>
                     {% endif %}
 
-                    {% set reviews = submission.getReviews() %}
-                    {% for review in reviews %}
+                    {% for review in submission.getReviews() %}
                         <p class="code">{{ 'Reviewer Notes' | t('workflow') }}: "{{ review.notes }}"</p>
                     {% endfor %}
                 </div>
@@ -84,8 +83,7 @@
                                 <p class="code">{{ 'Editor Notes' | t('workflow') }}: "{{ submission.editorNotes }}"</p>
                             {% endif %}
 
-                            {% set reviews = submission.getReviews() %}
-                            {% for review in reviews %}
+                            {% for review in submission.getReviews() %}
                                 <p class="code">{{ 'Reviewer Notes' | t('workflow') }}: "{{ review.notes }}"</p>
                             {% endfor %}
 
@@ -111,8 +109,7 @@
                                 <p class="code">{{ 'Editor Notes' | t('workflow') }}: "{{ submission.editorNotes }}"</p>
                             {% endif %}
 
-                            {% set reviews = submission.getReviews() %}
-                            {% for review in reviews %}
+                            {% for review in submission.getReviews() %}
                                 <p class="code">{{ 'Reviewer Notes' | t('workflow') }}: "{{ review.notes }}"</p>
                             {% endfor %}
 
@@ -138,8 +135,7 @@
                                 <p class="code">{{ 'Editor Notes' | t('workflow') }}: "{{ submission.editorNotes }}"</p>
                             {% endif %}
 
-                            {% set reviews = submission.getReviews() %}
-                            {% for review in reviews %}
+                            {% for review in submission.getReviews() %}
                                 <p class="code">{{ 'Reviewer Notes' | t('workflow') }}: "{{ review.notes }}"</p>
                             {% endfor %}
 

--- a/src/templates/_includes/reviewer-pane.html
+++ b/src/templates/_includes/reviewer-pane.html
@@ -18,7 +18,7 @@
 {% if pendingSubmissions | length %}
     {% set submission = pendingSubmissions[0] %}
 
-    {% if submission.canReviewerReview(currentUser) %}
+    {% if submission.canUserReview(currentUser) %}
         <div class="pane workflow-pane">
             <div class="workflow-submission">
                 <div class="workflow-submission-heading">

--- a/src/templates/_includes/reviewer-pane.html
+++ b/src/templates/_includes/reviewer-pane.html
@@ -22,64 +22,44 @@
         <div class="workflow-submission">
             <div class="workflow-submission-heading">
                 <span class="status pending"></span>
-                <label>{{ "Awaiting approval" | t('workflow') }}</label>
+                <label>{{ "Awaiting review" | t('workflow') }}</label>
                 <a class="fieldtoggle" data-target="workflow-submission-info"></a>
             </div>
 
             <div id="workflow-submission-info" class="hidden">
                 <div class="instructions">
-                    <p>{{ submission.editorUrl | raw }} {{ "submitted this entry for review on {date}. Please review this entry before publishing." | t('workflow', { date: submission.dateCreated | date('jS M Y g:ia') }) }}</p>
+                    <p>{{ submission.editorUrl | raw }} {{ "submitted this entry for review on {date}. Please review this entry before approving." | t('workflow', { date: submission.dateCreated | date('jS M Y g:ia') }) }}</p>
 
                     {% if submission.editorNotes %}
                         <p class="code">{{ 'Editor Notes' | t('workflow') }}: "{{ submission.editorNotes }}"</p>
                     {% endif %}
 
-                    {% if submission.publisherNotes %}
-                        <p class="code">{{ 'Publisher Notes' | t('workflow') }}: "{{ submission.publisherNotes }}"</p>
-                    {% endif %}
+                    {% set reviews = submission.getReviews() %}
+                    {% for review in reviews %}
+                        <p class="code">{{ 'Reviewer Notes' | t('workflow') }}: "{{ reviewer.notes }}"</p>
+                    {% endfor %}
                 </div>
             </div>
 
             <div class="workflow-submission-body">
-                {% set required = settings.publisherNotesRequired ? ' (required)' : '' %}
-
                 {{ forms.textareaField({
-                    placeholder: 'Notes about your response' ~ required ~ '.' | t('workflow'),
-                    id: 'publisherNotes',
-                    name: 'publisherNotes',
+                    placeholder: 'Notes about your response.' | t('workflow'),
+                    id: 'notes',
+                    name: 'notes',
                     class: 'field-notes',
                     rows: 2,
-                    required: settings.publisherNotesRequired,
-                    errors: publisherNotesErrors is defined ? publisherNotesErrors,
+                    errors: notesErrors is defined ? notesErrors,
                 }) }}
             </div>
 
             <input type="hidden" name="submissionId" value="{{ submission.id }}">
 
-            {% set endpoint = 'workflow/submissions/publish-entry' %}
-
-            {% if context.entry.getIsDraft() %}
-                {% set endpoint = 'workflow/submissions/publish-draft' %}
-            {% endif %}
-
-            <div class="workflow-submission-footer btngroup">
-                <div id="save-btn-container" class="btngroup submit">
-                    <a class="btn formsubmit submit" data-action="{{ endpoint }}" data-param="workflow-action" data-value="approve-submission" data-redirect="{{ craft.app.request.url | hash }}">{{ "Approve and publish" | t('workflow') }}</a>
-
-                    <div class="btn submit menubtn"></div>
-
-                    <div class="menu" data-align="right">
-                        <ul>
-                            <li>
-                                <a class="formsubmit" data-action="{{ endpoint }}" data-param="workflow-action" data-value="approve-only-submission" data-redirect="{{ craft.app.request.url | hash }}">
-                                    {{ "Approve only" | t('workflow') }}
-                                </a>
-                            </li>
-                        </ul>
-                    </div>
+            <div class="workflow-submission-footer">
+                <div id="save-btn-container" class="submit">
+                    <a class="btn formsubmit submit" data-action="workflow/submissions/save-draft" data-param="workflow-action" data-value="approve-review" data-redirect="{{ craft.app.request.url | hash }}">{{ "Approve" | t('workflow') }}</a>
                 </div>
 
-                <a class="formsubmit btn" data-action="workflow/submissions/save-draft" data-param="workflow-action" data-value="reject-submission" data-redirect="{{ craft.app.request.url | hash }}">{{ "Reject" | t('workflow') }}</a>
+                <a class="formsubmit btn" data-action="workflow/submissions/save-draft" data-param="workflow-action" data-value="reject-review" data-redirect="{{ craft.app.request.url | hash }}">{{ "Reject" | t('workflow') }}</a>
             </div>
         </div>
     </div>
@@ -104,6 +84,11 @@
                                 <p class="code">{{ 'Editor Notes' | t('workflow') }}: "{{ submission.editorNotes }}"</p>
                             {% endif %}
 
+                            {% set reviews = submission.getReviews() %}
+                            {% for review in reviews %}
+                                <p class="code">{{ 'Reviewer Notes' | t('workflow') }}: "{{ reviewer.notes }}"</p>
+                            {% endfor %}
+
                             {% if submission.publisherNotes %}
                                 <p class="code">{{ 'Publisher Notes' | t('workflow') }}: "{{ submission.publisherNotes }}"</p>
                             {% endif %}
@@ -126,6 +111,11 @@
                                 <p class="code">{{ 'Editor Notes' | t('workflow') }}: "{{ submission.editorNotes }}"</p>
                             {% endif %}
 
+                            {% set reviews = submission.getReviews() %}
+                            {% for review in reviews %}
+                                <p class="code">{{ 'Reviewer Notes' | t('workflow') }}: "{{ reviewer.notes }}"</p>
+                            {% endfor %}
+
                             {% if submission.publisherNotes %}
                                 <p class="code">{{ 'Publisher Notes' | t('workflow') }}: "{{ submission.publisherNotes }}"</p>
                             {% endif %}
@@ -147,6 +137,11 @@
                             {% if submission.editorNotes %}
                                 <p class="code">{{ 'Editor Notes' | t('workflow') }}: "{{ submission.editorNotes }}"</p>
                             {% endif %}
+
+                            {% set reviews = submission.getReviews() %}
+                            {% for review in reviews %}
+                                <p class="code">{{ 'Reviewer Notes' | t('workflow') }}: "{{ reviewer.notes }}"</p>
+                            {% endfor %}
 
                             {% if submission.publisherNotes %}
                                 <p class="code">{{ 'Publisher Notes' | t('workflow') }}: "{{ submission.publisherNotes }}"</p>

--- a/src/templates/settings/_panes/general.html
+++ b/src/templates/settings/_panes/general.html
@@ -55,14 +55,14 @@ table.editable tbody tr td:first-of-type:before {
 
 {{ forms.editableTableField({
     label: 'Reviewer User Groups' | t('workflow'),
-    instructions: 'Select the user groups that your reviewers belong to. Reviewers are users that can review submissions, edit them and pass them along for approval, but not publish live. The review process flows from the first to the last user group in the table.' | t('workflow'),
+    instructions: 'Select the user groups that your reviewers belong to. Reviewers are users that can review and edit submissions and pass them along for approval, but not publish live. The review process flows from the first to the last user group in the table.' | t('workflow'),
     name: 'reviewerUserGroups',
     id: 'reviewerUserGroups',
     cols: cols,
     rows: settings.reviewerUserGroups,
     addRowLabel: 'Add a user group' | t('workflow'),
     errors: settings.getErrors('reviewerUserGroups'),
-    warning: macros.configWarning('reviewerUserGroups', 'workflow') ?: 'Changing this may result in content being moved or lost in the review process.' | t('workflow'),
+    warning: macros.configWarning('reviewerUserGroups', 'workflow') ?: 'Changing this may result in submissions being lost in the review process.' | t('workflow'),
 })|spaceless }}
 
 <hr>

--- a/src/templates/settings/_panes/general.html
+++ b/src/templates/settings/_panes/general.html
@@ -18,11 +18,32 @@ table.editable tbody tr td:first-of-type:before {
     vertical-align: middle;
     margin-right: 5px;
 }
-table.editable tbody tr:first-of-type td:first-of-type:before {
-    content: 'disabled';
-}
 {% endcss %}
 
+
+{% set groupsWithNone = [{ label: "None" | t('workflow'), value: '' }] | merge(groups) %}
+
+{{ forms.selectField({
+    label: 'Editor User Group' | t('workflow'),
+    instructions: 'Select the user group that your editors belong to. Editors are users that can edit content, but not publish live.' | t('workflow'),
+    id: 'editorUserGroup',
+    name: 'editorUserGroup',
+    value: settings.editorUserGroup,
+    errors: settings.getErrors('editorUserGroup'),
+    options: groupsWithNone,
+    warning: macros.configWarning('editorUserGroup', 'workflow'),
+}) }}
+
+{{ forms.lightswitchField({
+    label: 'Editor Submission Notes Required' | t('workflow'),
+    instructions: 'Whether editors are required to enter a note in their submissions.' | t('workflow'),
+    id: 'editorNotesRequired',
+    name: 'editorNotesRequired',
+    on: settings.editorNotesRequired,
+    warning: macros.configWarning('editorNotesRequired', 'workflow'),
+}) }}
+
+<hr>
 
 {% set cols = [
     {
@@ -33,27 +54,16 @@ table.editable tbody tr:first-of-type td:first-of-type:before {
 ] %}
 
 {{ forms.editableTableField({
-    label: 'Editor User Groups' | t('workflow'),
-    instructions: 'Select the user groups that your editors belong to. The approval process will flow from the first user group to the last in the table below. Editors are users that can edit content and request approval, but not publish live.' | t('workflow'),
-    name: 'editorUserGroups',
-    id: 'editorUserGroups',
+    label: 'Reviewer User Groups' | t('workflow'),
+    instructions: 'Select the user groups that your reviewers belong to. Reviewers are users that can review submissions, edit them and pass them along for approval, but not publish live. The review process flows from the first to the last user group in the table.' | t('workflow'),
+    name: 'reviewerUserGroups',
+    id: 'reviewerUserGroups',
     cols: cols,
-    rows: settings.editorUserGroups,
+    rows: settings.reviewerUserGroups,
     addRowLabel: 'Add a user group' | t('workflow'),
-    errors: settings.getErrors('editorUserGroups'),
-    required: true,
-    warning: macros.configWarning('editorUserGroups', 'workflow') ?: 'Changing this may result in content being moved or lost in the approval process.' | t('workflow'),
+    errors: settings.getErrors('reviewerUserGroups'),
+    warning: macros.configWarning('reviewerUserGroups', 'workflow') ?: 'Changing this may result in content being moved or lost in the review process.' | t('workflow'),
 })|spaceless }}
-
-
-{{ forms.lightswitchField({
-    label: 'Editor Submission Notes Required' | t('workflow'),
-    instructions: 'Whether editors are required to enter a note in their submissions.' | t('workflow'),
-    id: 'editorNotesRequired',
-    name: 'editorNotesRequired',
-    on: settings.editorNotesRequired,
-    warning: macros.configWarning('editorNotesRequired', 'workflow'),
-}) }}
 
 <hr>
 

--- a/src/templates/settings/_panes/general.html
+++ b/src/templates/settings/_panes/general.html
@@ -1,22 +1,50 @@
 {% import '_includes/forms' as forms %}
 {% import 'verbb-base/_macros' as macros %}
 
-{% set groups = [{ label: "None" | t('workflow'), value: '' }] %}
+{% set groups = [] %}
 {% for group in craft.app.userGroups.getAllGroups() %}
     {% set groups = groups | merge([{ label: group.name, value: group.uid }]) %}
 {% endfor %}
 
-{{ forms.selectField({
-    label: 'Editor User Group' | t('workflow'),
-    instructions: 'Select the user group that your editors belong to. Editors are users that can edit content, but not publish live.' | t('workflow'),
-    id: 'editorUserGroup',
-    name: 'editorUserGroup',
-    value: settings.editorUserGroup,
-    errors: settings.getErrors('editorUserGroup'),
+{# TODO: add to Sass file #}
+{% css %}
+table.editable tbody tr td {
+    text-align: left;
+}
+table.editable tbody tr td:first-of-type:before {
+    font-family: 'Craft';
+    content: 'rarr';
+    color: #9aa5b1;
+    vertical-align: middle;
+    margin-right: 5px;
+}
+table.editable tbody tr:first-of-type td:first-of-type:before {
+    content: 'disabled';
+}
+{% endcss %}
+
+
+{% set cols = [
+    {
+        type: 'select',
+        heading: 'User Group' | t('workflow'),
+        options: groups,
+    },
+] %}
+
+{{ forms.editableTableField({
+    label: 'Editor User Groups' | t('workflow'),
+    instructions: 'Select the user groups that your editors belong to. The approval process will flow from the first user group to the last in the table below. Editors are users that can edit content and request approval, but not publish live.' | t('workflow'),
+    name: 'editorUserGroups',
+    id: 'editorUserGroups',
+    cols: cols,
+    rows: settings.editorUserGroups,
+    addRowLabel: 'Add a user group' | t('workflow'),
+    errors: settings.getErrors('editorUserGroups'),
     required: true,
-    options: groups,
-    warning: macros.configWarning('editorUserGroup', 'workflow'),
-}) }}
+    warning: macros.configWarning('editorUserGroups', 'workflow') ?: 'Changing this may result in content being moved or lost in the approval process.' | t('workflow'),
+})|spaceless }}
+
 
 {{ forms.lightswitchField({
     label: 'Editor Submission Notes Required' | t('workflow'),

--- a/src/templates/settings/_panes/notifications.html
+++ b/src/templates/settings/_panes/notifications.html
@@ -12,11 +12,13 @@
 
 {{ forms.checkboxGroupField({
     label: 'Editor Notifications - Additional Options' | t('workflow'),
-    instructions: 'Whether editor notifications should include the publisher\'s email whose triggered the action.' | t('workflow'),
+    instructions: 'Whether editor notifications should include the reviewer\'s or publisher\'s email whose triggered the action.' | t('workflow'),
     id: 'editorNotificationsOptions',
     name: 'editorNotificationsOptions',
     values: settings.editorNotificationsOptions,
     options: {
+        replyToReviewer: 'Reply-To Reviewer Email' | t('workflow'),
+        ccReviewer: 'CC Reviewer Email' | t('workflow'),
         replyTo: 'Reply-To Publisher Email' | t('workflow'),
         cc: 'CC Publisher Email' | t('workflow'),
     },

--- a/src/templates/settings/_panes/notifications.html
+++ b/src/templates/settings/_panes/notifications.html
@@ -26,6 +26,17 @@
 <hr>
 
 {{ forms.lightswitchField({
+    label: 'Reviewer Notifications' | t('workflow'),
+    instructions: 'Whether email notifications should be delivered to reviewers when editors submit an entry for review.' | t('workflow'),
+    id: 'reviewerNotifications',
+    name: 'reviewerNotifications',
+    on: settings.reviewerNotifications,
+    warning: macros.configWarning('reviewerNotifications', 'workflow'),
+}) }}
+
+<hr>
+
+{{ forms.lightswitchField({
     label: 'Publisher Notifications' | t('workflow'),
     instructions: 'Whether email notifications should be delivered to publishers when editors submit an entry for review.' | t('workflow'),
     id: 'publisherNotifications',

--- a/src/templates/settings/_panes/permissions.html
+++ b/src/templates/settings/_panes/permissions.html
@@ -8,7 +8,7 @@
 
 {{ forms.checkboxSelectField({
     label: 'Enabled Sections' | t('workflow'),
-    instructions: 'Select which sections you require editor-publisher workflow enabled for.' | t('workflow'),
+    instructions: 'Select which sections you require the workflow to be enabled for.' | t('workflow'),
     id: 'enabledSections',
     name: 'enabledSections',
     values: settings.enabledSections,

--- a/src/templates/settings/_panes/permissions.html
+++ b/src/templates/settings/_panes/permissions.html
@@ -8,7 +8,7 @@
 
 {{ forms.checkboxSelectField({
     label: 'Enabled Sections' | t('workflow'),
-    instructions: 'Select which sections you require the workflow to be enabled for.' | t('workflow'),
+    instructions: 'Select which sections the workflow should be enabled for.' | t('workflow'),
     id: 'enabledSections',
     name: 'enabledSections',
     values: settings.enabledSections,

--- a/src/translations/en/workflow.php
+++ b/src/translations/en/workflow.php
@@ -13,12 +13,12 @@ return [
         "To review it please log into your control panel.\n\n" .
         "{{ submission.cpEditUrl }}",
 
-    'workflow_reviewer_notification_heading' => 'When an editor submits entry for review:',
-    'workflow_reviewer_notification_subject' => '"{{ submission.owner.title }}" has been submitted for review on {{ siteName }}.',
-    'workflow_reviewer_notification_body' => "Hey {{ user.friendlyName }},\n\n" .
-        "{{ submission.editor }} has submitted the entry \"{{ submission.owner.title }}\" for review on {{ siteName }}.\n\n" .
-        "{% if submission.editorNotes %}Notes: \"{{ submission.editorNotes }}\"\n\n{% endif %}" .
-        "To review it please log into your control panel.\n\n" .
+    'workflow_editor_review_notification_heading' => 'When a reviewer approves or rejects an editor submission:',
+    'workflow_editor_review_notification_subject' => 'Your submission for "{{ submission.owner.title }}" has been {{ review.approved ? \'approved\' : \'rejected\' }} on {{ siteName }}.',
+    'workflow_editor_review_notification_body' => "Hey {{ user.friendlyName }},\n\n" .
+        "Your submission for {{ submission.owner.title }} has been {{ review.approved ? 'approved' : 'rejected' }} {{ review.dateCreated | date }} on {{ siteName }}.\n\n" .
+        "{% if review.notes %}Notes: \"{{ review.notes }}\"\n\n{% endif %}" .
+        "View your submission by logging into your control panel.\n\n" .
         "{{ submission.cpEditUrl }}",
 
     'workflow_editor_notification_heading' => 'When a publisher approves or rejects an editor submission:',
@@ -26,14 +26,6 @@ return [
     'workflow_editor_notification_body' => "Hey {{ user.friendlyName }},\n\n" .
         "Your submission for {{ submission.owner.title }} has been {{ submission.status }} {{ (submission.status == 'approved') ? submission.dateApproved | date : submission.dateRejected | date }} on {{ siteName }}.\n\n" .
         "{% if submission.publisherNotes %}Notes: \"{{ submission.publisherNotes }}\"\n\n{% endif %}" .
-        "View your submission by logging into your control panel.\n\n" .
-        "{{ submission.cpEditUrl }}",
-
-    'workflow_editor_review_notification_heading' => 'When a reviewer approves or rejects an editor submission:',
-    'workflow_editor_review_notification_subject' => 'Your submission for "{{ submission.owner.title }}" has been {{ review.approved ? \'approved\' : \'rejected\' }} on {{ siteName }}.',
-    'workflow_editor_review_notification_body' => "Hey {{ user.friendlyName }},\n\n" .
-        "Your submission for {{ submission.owner.title }} has been {{ review.approved ? 'approved' : 'rejected' }} {{ review.dateCreated | date }} on {{ siteName }}.\n\n" .
-        "{% if review.notes %}Notes: \"{{ review.notes }}\"\n\n{% endif %}" .
         "View your submission by logging into your control panel.\n\n" .
         "{{ submission.cpEditUrl }}",
 ];

--- a/src/translations/en/workflow.php
+++ b/src/translations/en/workflow.php
@@ -5,14 +5,6 @@ return [
     // Email Messages
     //
 
-    'workflow_reviewer_notification_heading' => 'When an editor submits entry for approval:',
-    'workflow_reviewer_notification_subject' => '"{{ submission.owner.title }}" has been submitted for approval on {{ siteName }}.',
-    'workflow_reviewer_notification_body' => "Hey {{ user.friendlyName }},\n\n" .
-        "{{ submission.editor }} has submitted the entry \"{{ submission.owner.title }}\" for approval on {{ siteName }}.\n\n" .
-        "{% if submission.editorNotes %}Notes: \"{{ submission.editorNotes }}\"\n\n{% endif %}" .
-        "To review it please log into your control panel.\n\n" .
-        "{{ submission.cpEditUrl }}",
-
     'workflow_publisher_notification_heading' => 'When an editor submits entry for approval:',
     'workflow_publisher_notification_subject' => '"{{ submission.owner.title }}" has been submitted for approval on {{ siteName }}.',
     'workflow_publisher_notification_body' => "Hey {{ user.friendlyName }},\n\n" .
@@ -21,7 +13,15 @@ return [
         "To review it please log into your control panel.\n\n" .
         "{{ submission.cpEditUrl }}",
 
-    'workflow_editor_notification_heading' => 'When a reviewer or publisher approves or rejects an editor submission:',
+    'workflow_reviewer_notification_heading' => 'When a reviewer approves or rejects an editor submission:',
+    'workflow_reviewer_notification_subject' => 'Your submission for "{{ submission.owner.title }}" has been {{ review.approved ? \'approved\' : \'rejected\' }} on {{ siteName }}.',
+    'workflow_reviewer_notification_body' => "Hey {{ user.friendlyName }},\n\n" .
+        "Your submission for {{ submission.owner.title }} has been {{ review.approved ? 'approved' : 'rejected' }} {{ review.dateCreated | date }} on {{ siteName }}.\n\n" .
+        "{% if review.notes %}Notes: \"{{ review.notes }}\"\n\n{% endif %}" .
+        "View your submission by logging into your control panel.\n\n" .
+        "{{ submission.cpEditUrl }}",
+
+    'workflow_editor_notification_heading' => 'When a publisher approves or rejects an editor submission:',
     'workflow_editor_notification_subject' => 'Your submission for "{{ submission.owner.title }}" has been {{ submission.status }} on {{ siteName }}.',
     'workflow_editor_notification_body' => "Hey {{ user.friendlyName }},\n\n" .
         "Your submission for {{ submission.owner.title }} has been {{ submission.status }} {{ (submission.status == 'approved') ? submission.dateApproved | date : submission.dateRejected | date }} on {{ siteName }}.\n\n" .

--- a/src/translations/en/workflow.php
+++ b/src/translations/en/workflow.php
@@ -4,7 +4,15 @@ return [
     //
     // Email Messages
     //
-    
+
+    'workflow_reviewer_notification_heading' => 'When an editor submits entry for approval:',
+    'workflow_reviewer_notification_subject' => '"{{ submission.owner.title }}" has been submitted for approval on {{ siteName }}.',
+    'workflow_reviewer_notification_body' => "Hey {{ user.friendlyName }},\n\n" .
+        "{{ submission.editor }} has submitted the entry \"{{ submission.owner.title }}\" for approval on {{ siteName }}.\n\n" .
+        "{% if submission.editorNotes %}Notes: \"{{ submission.editorNotes }}\"\n\n{% endif %}" .
+        "To review it please log into your control panel.\n\n" .
+        "{{ submission.cpEditUrl }}",
+
     'workflow_publisher_notification_heading' => 'When an editor submits entry for approval:',
     'workflow_publisher_notification_subject' => '"{{ submission.owner.title }}" has been submitted for approval on {{ siteName }}.',
     'workflow_publisher_notification_body' => "Hey {{ user.friendlyName }},\n\n" .
@@ -13,7 +21,7 @@ return [
         "To review it please log into your control panel.\n\n" .
         "{{ submission.cpEditUrl }}",
 
-    'workflow_editor_notification_heading' => 'When a publisher approves or rejects an editor submission:',
+    'workflow_editor_notification_heading' => 'When a reviewer or publisher approves or rejects an editor submission:',
     'workflow_editor_notification_subject' => 'Your submission for "{{ submission.owner.title }}" has been {{ submission.status }} on {{ siteName }}.',
     'workflow_editor_notification_body' => "Hey {{ user.friendlyName }},\n\n" .
         "Your submission for {{ submission.owner.title }} has been {{ submission.status }} {{ (submission.status == 'approved') ? submission.dateApproved | date : submission.dateRejected | date }} on {{ siteName }}.\n\n" .

--- a/src/translations/en/workflow.php
+++ b/src/translations/en/workflow.php
@@ -13,12 +13,12 @@ return [
         "To review it please log into your control panel.\n\n" .
         "{{ submission.cpEditUrl }}",
 
-    'workflow_reviewer_notification_heading' => 'When a reviewer approves or rejects an editor submission:',
-    'workflow_reviewer_notification_subject' => 'Your submission for "{{ submission.owner.title }}" has been {{ review.approved ? \'approved\' : \'rejected\' }} on {{ siteName }}.',
+    'workflow_reviewer_notification_heading' => 'When an editor submits entry for review:',
+    'workflow_reviewer_notification_subject' => '"{{ submission.owner.title }}" has been submitted for review on {{ siteName }}.',
     'workflow_reviewer_notification_body' => "Hey {{ user.friendlyName }},\n\n" .
-        "Your submission for {{ submission.owner.title }} has been {{ review.approved ? 'approved' : 'rejected' }} {{ review.dateCreated | date }} on {{ siteName }}.\n\n" .
-        "{% if review.notes %}Notes: \"{{ review.notes }}\"\n\n{% endif %}" .
-        "View your submission by logging into your control panel.\n\n" .
+        "{{ submission.editor }} has submitted the entry \"{{ submission.owner.title }}\" for review on {{ siteName }}.\n\n" .
+        "{% if submission.editorNotes %}Notes: \"{{ submission.editorNotes }}\"\n\n{% endif %}" .
+        "To review it please log into your control panel.\n\n" .
         "{{ submission.cpEditUrl }}",
 
     'workflow_editor_notification_heading' => 'When a publisher approves or rejects an editor submission:',
@@ -26,6 +26,14 @@ return [
     'workflow_editor_notification_body' => "Hey {{ user.friendlyName }},\n\n" .
         "Your submission for {{ submission.owner.title }} has been {{ submission.status }} {{ (submission.status == 'approved') ? submission.dateApproved | date : submission.dateRejected | date }} on {{ siteName }}.\n\n" .
         "{% if submission.publisherNotes %}Notes: \"{{ submission.publisherNotes }}\"\n\n{% endif %}" .
+        "View your submission by logging into your control panel.\n\n" .
+        "{{ submission.cpEditUrl }}",
+
+    'workflow_editor_review_notification_heading' => 'When a reviewer approves or rejects an editor submission:',
+    'workflow_editor_review_notification_subject' => 'Your submission for "{{ submission.owner.title }}" has been {{ review.approved ? \'approved\' : \'rejected\' }} on {{ siteName }}.',
+    'workflow_editor_review_notification_body' => "Hey {{ user.friendlyName }},\n\n" .
+        "Your submission for {{ submission.owner.title }} has been {{ review.approved ? 'approved' : 'rejected' }} {{ review.dateCreated | date }} on {{ siteName }}.\n\n" .
+        "{% if review.notes %}Notes: \"{{ review.notes }}\"\n\n{% endif %}" .
         "View your submission by logging into your control panel.\n\n" .
         "{{ submission.cpEditUrl }}",
 ];


### PR DESCRIPTION
This PR adds an optional multi-step review process, by adding a Reviewer User Groups table setting to the plugin. By default, the table is empty, making updating seamless and the review process opt-in.

![Screenshot 2020-05-14 at 09 47 47](https://user-images.githubusercontent.com/57572400/81907468-1bc34000-95c8-11ea-82a4-3cd3d57309b1.png)

![Screenshot 2020-05-14 at 09 47 19](https://user-images.githubusercontent.com/57572400/81907527-31386a00-95c8-11ea-9128-2d4832fe219c.png)
