### PR TITLE
Fixed grammatical error in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Workflow is a Craft CMS plugin for a common publisher-editor scenario when it co
 
 - Makes use of Craft's native user permissions.
 - Choose which user groups are your Editor and Publisher roles.
-- Email notifications to Publisher group, which editable content.
+- Email notifications to the Publisher group when content is ready for review.
 - Events for third-party plugins to hook into for submissions.
 
 ## Documentation
@@ -18,8 +18,6 @@ Visit the [Workflow Plugin page](https://verbb.io/craft-plugins/workflow) for al
 ## Support
 
 Get in touch with us via the [Workflow Support page](https://verbb.io/craft-plugins/workflow/support) or by [creating a Github issue](https://github.com/verbb/workflow/issues)
-
-<h2></h2>
 
 <a href="https://verbb.io" target="_blank">
   <img width="100" src="https://verbb.io/assets/img/verbb-pill.svg">


### PR DESCRIPTION
I think this only affects the readme in the repo, but the same text is used on https://plugins.craftcms.com/workflow.

Additionally on the plugin store page, I'd recommend changing this:

> Publishers should review all changes and content is appropriate, after which they can accept or reject the submission, also providing any comments of their response.

To this:

> Publishers should review all the changes and that the content is appropriate, after which they can accept or reject the submission, also providing any comments in their response.