### PR TITLE
Updated to use "after save element" so you have access to matrix data

### DIFF
--- a/src/Workflow.php
+++ b/src/Workflow.php
@@ -147,7 +147,7 @@ class Workflow extends Plugin
         }
 
         Event::on(Entry::class, Entry::EVENT_BEFORE_SAVE, [$this->getService(), 'onBeforeSaveEntry']);
-        Event::on(Entry::class, Entry::EVENT_AFTER_SAVE, [$this->getService(), 'onAfterSaveEntry']);
+        Event::on(Entry::class, Entry::EVENT_AFTER_SAVE_ELEMENT, [$this->getService(), 'onAfterSaveEntry']);
 
         Event::on(Drafts::class, Drafts::EVENT_AFTER_APPLY_DRAFT, [$this->getService(), 'onAfterApplyDraft']);
     }

--- a/src/elements/Submission.php
+++ b/src/elements/Submission.php
@@ -166,6 +166,13 @@ class Submission extends Element
 
         return '';
     }
+    
+    public function setOwner($owner)
+    {
+        $this->_owner = $owner;
+
+        return $this;
+    }
 
     public function getOwner()
     {

--- a/src/services/Submissions.php
+++ b/src/services/Submissions.php
@@ -98,6 +98,7 @@ class Submissions extends Component
         $session = Craft::$app->getSession();
 
         $submission = $this->_setSubmissionFromPost();
+        $submission->setOwner($entry);
         $submission->ownerId = $entry->id;
         $submission->ownerSiteId = $entry->siteId;
         $submission->editorId = $currentUser->id;


### PR DESCRIPTION
I'm not sure this is the _best_ fix but wanted to document an issue for you and propose a potential solution.

Workflow hooks in to `Entry::EVENT_AFTER_SAVE` to save workflow submissions against an entry. Then, I'm using the `Submission::EVENT_AFTER_SAVE` hook to send additional notifications to editors when things change (via Slack). This is causing a problem because some of the data we need access to is stored in a matrix block (and not accessible to the submission). The simplified stack trace looks like this (most recent at the top, like a normal stack trace, read it bottom to top),

```
8. Webhook
7. services\Elements::afterSave()
6. services\Elements::saveElement($submission)
5. Workflow::onAfterSaveEntry() -- here Workflow creates a new submission and saves that submission, a Submission is an element so the Element lifecycle happens again
4. $event->trigger('afterSave')
3. services\Elements::afterSave()
2. services\Elements::saveElement($entry)
1. $entry->save()
```

The problem is that inside `services\Elements::_saveElementInternal()` there's the `$element->afterSave()` and then a little bit lower is `$element->afterPropagate()`. Importantly, `afterSave` runs before `afterPropagate`.

Now, the monkey wrench: `fields\Matrix` does its logic in `EVENT_AFTER_PROPAGATE`/`afterElementPropagate`.

That means (in the above stack trace) that `8. Webhook` has no access to any matrix data from `$entry` because it actually hasn't been saved to the database by the time `EVENT_AFTER_SAVE` runs. It won't be saved until after our web hook runs.

There were a few ways you could handle this.

1. Move Workflow to listen to `EVENT_AFTER_SAVE_ELEMENT` (which runs after _everything_)
2. Pass the `$entry` from line 1 up to line 8

Both these fixes are in PR. Neither are fully tested, they work for me, but that's one very specific site. Curious your thoughts.