### PR TITLE
Fix submission docs. after and before does not exist (Craft 3)

### DIFF
--- a/docs/getting-elements/submission-queries.md
+++ b/docs/getting-elements/submission-queries.md
@@ -48,38 +48,6 @@ Submission queries support the following parameters:
 
 <!-- BEGIN PARAMS -->
 
-### `after`
-Narrows the query results to only submissions that were posted on or after a certain date.
-
-Possible values include:
-
-| Value | Fetches submissions…
-| - | -
-| `'2018-04-01'` | that were posted after 2018-04-01.
-| a [DateTime](http://php.net/class.datetime) object | that were posted after the date represented by the object.
-
-::: code
-```twig Twig
-{# Fetch submissions posted this month #}
-{% set firstDayOfMonth = date('first day of this month') %}
-
-{% set submissions = craft.workflow.submissions()
-    .after(firstDayOfMonth)
-    .all() %}
-```
-
-```php PHP
-// Fetch submissions posted this month
-$firstDayOfMonth = new \DateTime('first day of this month');
-
-$submissions = \verbb\workflow\elements\Submission::find()
-    ->after($firstDayOfMonth)
-    ->all();
-```
-:::
-
-
-
 ### `anyStatus`
 
 Clears out the [status()](https://docs.craftcms.com/api/v3/craft-elements-db-elementquery.html#method-status) and [enabledForSite()](https://docs.craftcms.com/api/v3/craft-elements-db-elementquery.html#method-enabledforsite) parameters.
@@ -118,39 +86,6 @@ Causes the query to return matching submissions as arrays of data, rather than [
 // Fetch submissions as arrays
 $submissions = \verbb\workflow\elements\Submission::find()
     ->asArray()
-    ->all();
-```
-:::
-
-
-
-### `before`
-
-Narrows the query results to only submissions that were posted before a certain date.
-
-Possible values include:
-
-| Value | Fetches submissions…
-| - | -
-| `'2018-04-01'` | that were posted before 2018-04-01.
-| a [DateTime](http://php.net/class.datetime) object | that were posted before the date represented by the object.
-
-::: code
-```twig Twig
-{# Fetch submissions posted before this month #}
-{% set firstDayOfMonth = date('first day of this month') %}
-
-{% set submissions = craft.workflow.submissions()
-    .before(firstDayOfMonth)
-    .all() %}
-```
-
-```php PHP
-// Fetch submissions posted before this month
-$firstDayOfMonth = new \DateTime('first day of this month');
-
-$submissions = \verbb\workflow\elements\Submission::find()
-    ->before($firstDayOfMonth)
     ->all();
 ```
 :::


### PR DESCRIPTION
The `after` and `before` parameter doesn't exist in Submission Query. `dateCreated` can be used instead.

The same issue that was already fixed in Formie: https://github.com/verbb/formie/issues/180

(Same change as in Craft 4 branch -> https://github.com/verbb/workflow/pull/188)