### PR TITLE
[2.x] Fix ElementHelper::supportedSitesForElement issue

### DIFF
--- a/src/elements/Submission.php
+++ b/src/elements/Submission.php
@@ -196,7 +196,7 @@ class Submission extends Element
             return $owner->getSupportedSites();
         }
 
-        return Craft::$app->getSites()->getAllSites();
+        return Craft::$app->getSites()->getAllSiteIds();
     }
 
     public function setOwner(Entry $owner): void


### PR DESCRIPTION
I'm upgrading a site to Craft 4 and have installed Workflow 2.0.12. When I approve a submission and save I get an exception:

```
yii\base\ErrorException: Object of class craft\models\Site could not be converted to int in /var/www/html/vendor/craftcms/cms/src/helpers/ElementHelper.php:298
Stack trace:
#0 /var/www/html/vendor/craftcms/cms/src/web/ErrorHandler.php(79): craft\web\ErrorHandler->handleError('2', ''Object of clas...', ''/var/www/html/...', '298')
#1 /var/www/html/vendor/craftcms/cms/src/helpers/ElementHelper.php(298): craft\web\ErrorHandler->handleError('2', ''Object of clas...', ''/var/www/html/...', '298')
#2 /var/www/html/vendor/craftcms/cms/src/helpers/ElementHelper.php(336): craft\helpers\ElementHelper::supportedSitesForElement('class verbb\\wor...', 'TRUE')
#3 /var/www/html/vendor/putyourlightson/craft-blitz/src/behaviors/ElementChangedBehavior.php(86): craft\helpers\ElementHelper::siteStatusesForElement('class verbb\\wor...', '???')
#4 /var/www/html/vendor/yiisoft/yii2/base/Component.php(773): putyourlightson\blitz\behaviors\ElementChangedBehavior->attach('class verbb\\wor...')
#5 /var/www/html/vendor/yiisoft/yii2/base/Component.php(692): verbb\workflow\elements\Submission->attachBehaviorInternal(''elementChanged...', ''putyourlightso...')
#6 /var/www/html/vendor/putyourlightson/craft-blitz/src/Blitz.php(394): verbb\workflow\elements\Submission->attachBehavior(''elementChanged...', ''putyourlightso...')
#7 /var/www/html/vendor/yiisoft/yii2/base/Event.php(312): putyourlightson\blitz\Blitz->putyourlightson\blitz\{closure:/var/www/html/vendor/putyourlightson/craft-blitz/src/Blitz.php:390-396}('class craft\\eve...')
#8 /var/www/html/vendor/yiisoft/yii2/base/Event.php(312): ::call_user_func:{/var/www/html/vendor/yiisoft/yii2/base/Event.php:312}(callback: 'class Closure {...', args: Array)
#9 /var/www/html/vendor/yiisoft/yii2/base/Component.php(650): yii\base\Event::trigger(class: 'class craft\\ser...', name: ''beforeSaveElem...', event: 'class craft\\eve...')
#10 /var/www/html/vendor/craftcms/cms/src/services/Elements.php(3241): craft\services\Elements->trigger(name: ''beforeSaveElem...', event: 'class craft\\eve...')
#11 /var/www/html/vendor/craftcms/cms/src/services/Elements.php(1115): craft\services\Elements->_saveElementInternal(element: 'class verbb\\wor...', runValidation: 'TRUE', propagate: 'TRUE', updateSearchIndex: 'NULL', supportedSites: 'NULL', forceTouch: 'FALSE', crossSiteValidate: 'FALSE')
#12 /var/www/html/vendor/verbb/workflow/src/controllers/SubmissionsController.php(94): craft\services\Elements->saveElement(element: 'class verbb\\wor...', runValidation: '???', propagate: '???', updateSearchIndex: '???', forceTouch: '???', crossSiteValidate: '???')
#13 /var/www/html/vendor/yiisoft/yii2/base/InlineAction.php(57): verbb\workflow\controllers\SubmissionsController->actionSaveSubmission()
#14 /var/www/html/vendor/yiisoft/yii2/base/InlineAction.php(57): ::call_user_func_array:{/var/www/html/vendor/yiisoft/yii2/base/InlineAction.php:57}(callback: '[0 => class ver...', args: '[]')
#15 /var/www/html/vendor/yiisoft/yii2/base/Controller.php(178): yii\base\InlineAction->runWithParams(params: '['site' => 'hun...')
#16 /var/www/html/vendor/yiisoft/yii2/base/Module.php(552): verbb\workflow\controllers\SubmissionsController->runAction(id: ''save-submissio...', params: '['site' => 'hun...')
#17 /var/www/html/vendor/craftcms/cms/src/web/Application.php(341): craft\web\Application->runAction(route: ''workflow/submi...', params: '['site' => 'hun...')
#18 /var/www/html/vendor/craftcms/cms/src/web/Application.php(640): craft\web\Application->runAction(route: ''workflow/submi...', params: '['site' => 'hun...')
#19 /var/www/html/vendor/craftcms/cms/src/web/Application.php(303): craft\web\Application->_processActionRequest(request: 'class craft\\web...')
#20 /var/www/html/vendor/yiisoft/yii2/base/Application.php(384): craft\web\Application->handleRequest(request: 'class craft\\web...', skipSpecialHandling: '???')
#21 /var/www/html/public/index.php(11): craft\web\Application->run()
#22 {main}
```

There don't appear to have been any changes to the Craft Elements helper in years related to the `supportedSitesForElement` method (https://github.com/craftcms/cms/blame/5.x/src/helpers/ElementHelper.php#L318) so that suggests the issue isn't related to the Craft update.

When looking at other implementations of the `getSupportedSites()` method they all return an array of arrays or IDs which is what the `ElementHelper::supportedSitesForElement()` is expecting to work with.

The fix I found was to alter the return value for the Submission element's `getSupportedSites()` method to the `getAllSiteIds()` instead.