### PR TITLE
Fix syntax error in SubmissionsController::actionSaveSubmission

### DIFF
--- a/src/controllers/SubmissionsController.php
+++ b/src/controllers/SubmissionsController.php
@@ -85,7 +85,8 @@ class SubmissionsController extends Controller
                         'errors' => $submission->getErrors(),
                     ]);
 
-                return null;
+                    return null;
+                }
             } else if ($status === Review::STATUS_PENDING) {
                 $session->setError(Craft::t('workflow', 'You cannot change a submission to pending once created.'));
 
@@ -96,7 +97,7 @@ class SubmissionsController extends Controller
 
                 return null;
             } else {
-            Workflow::$plugin->getSubmissions()->triggerSubmissionStatus($status, $submission);
+                Workflow::$plugin->getSubmissions()->triggerSubmissionStatus($status, $submission);
             }
         }
 


### PR DESCRIPTION
## Summary

Version 3.0.15 of this plugin ships a `SubmissionsController.php` that does not parse:

```
PHP Parse error: syntax error, unexpected token "public" in
vendor/verbb/workflow/src/controllers/SubmissionsController.php on line 119
```

In `actionSaveSubmission()`, the inner `if (!Workflow::$plugin->getSubmissions()->canUserApproveOwnSubmission(...))` block is missing its closing brace before the `else if ($status === Review::STATUS_PENDING)` branch. Because of that, the outer `if ($submission->status !== $status)` block is never closed, the method body bleeds past its intended end, and PHP fails on the next `public function actionDeleteSubmission()` declaration.

This makes the plugin completely unloadable on a fresh install of 3.0.15 — Craft fails to boot as soon as the controller is autoloaded.

## Changes

- Add the missing `}` that closes the inner `if (!canUserApproveOwnSubmission(...))` block.
- Re-indent the two lines that were dedented as a side-effect of the missing brace (`return null;` and the `triggerSubmissionStatus(...)` call) so they line up with their surrounding scope.

## Test plan

- [x] `php -l src/controllers/SubmissionsController.php` reports no syntax errors after the change.
- [ ] Verify the branch behaviour in the CP: approve-own / pending / regular status changes each take the intended path.